### PR TITLE
fix: 1文字のみ入力されている状態の場合、ライブ変換を適用しない

### DIFF
--- a/azooKeyMac/azooKeyMacInputController.swift
+++ b/azooKeyMac/azooKeyMacInputController.swift
@@ -425,7 +425,7 @@ class azooKeyMacInputController: IMKInputController {
             self.composingText.insertAtCursorPosition(string, inputStyle: .roman2kana)
             self.updateRawCandidate()
             // Live Conversion
-            let text = if self.liveConversionEnabled, let firstCandidate = self.rawCandidates?.mainResults.first {
+            let text = if self.liveConversionEnabled, self.composingText.convertTarget.count > 1, let firstCandidate = self.rawCandidates?.mainResults.first {
                 firstCandidate.text
             } else {
                 self.composingText.convertTarget


### PR DESCRIPTION
ライブ変換中、1文字のみの入力でもライブ変換が適用され、使いづらい問題があった。この修正ではライブ変換の適用を2文字以上に限定することでこの問題を解決する。