### PR TITLE
fix: escapeを押した場合の挙動を修正

### DIFF
--- a/azooKeyMac/InputController/Actions/ClientAction.swift
+++ b/azooKeyMac/InputController/Actions/ClientAction.swift
@@ -16,6 +16,8 @@ indirect enum ClientAction {
     case forwardToCandidateWindow(NSEvent)
     case selectInputMode(InputMode)
 
+    case stopComposition
+
     enum InputMode {
         case roman
         case japanese

--- a/azooKeyMac/InputController/Actions/UserAction.swift
+++ b/azooKeyMac/InputController/Actions/UserAction.swift
@@ -4,6 +4,7 @@ enum UserAction {
     case delete
     case enter
     case space
+    case escape
     case unknown
     case 英数
     case かな

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -13,7 +13,7 @@ enum InputMode {
         case 51: // Delete
             return .delete
         case 53: // Escape
-            return .unknown
+            return .escape
         case 93: // Yen
             switch (Config.TypeBackSlash().value, event.modifierFlags.contains(.shift), event.modifierFlags.contains(.option)) {
             case (_, true, _):

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -26,7 +26,7 @@ enum InputState {
                 return .selectInputMode(.japanese)
             case .英数:
                 return .selectInputMode(.roman)
-            case .unknown, .navigation, .space, .delete, .enter:
+            case .unknown, .navigation, .space, .delete, .enter, .escape:
                 return .fallthrough
             }
         case .composing:
@@ -38,6 +38,8 @@ enum InputState {
             case .enter:
                 self = .none
                 return .commitMarkedText
+            case .escape:
+                return .stopComposition
             case .space:
                 self = .selecting(rangeAdjusted: false)
                 return .showCandidateWindow
@@ -74,6 +76,9 @@ enum InputState {
             case .delete:
                 self = .composing
                 return .removeLastMarkedText
+            case .escape:
+                self = .composing
+                return .hideCandidateWindow
             case .space:
                 // Spaceは下矢印キーに、Shift + Spaceは上矢印キーにマップする
                 // 下矢印キー: \u{F701} / 125

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -256,6 +256,12 @@ class azooKeyMacInputController: IMKInputController {
             return false
         case .forwardToCandidateWindow(let event):
             self.candidatesWindow.interpretKeyEvents([event])
+        case .stopComposition:
+            self.updateMarkedTextInComposingMode(text: "", client: client)
+            self.composingText.stopComposition()
+            self.kanaKanjiConverter.stopComposition()
+            self.candidatesWindow.hide()
+            self.displayedTextInComposingMode = nil
         case .sequence(let actions):
             var found = false
             for action in actions {


### PR DESCRIPTION
現在のazooKey on macOSでは入力中にEscapeを押した場合の挙動が入力のリセットではなく「見た目上消える」というものになっていたので、明示的にハンドリング処理を書いて解決した。