### PR TITLE
feat: shift+spaceで1つ上の候補を選択する機能を追加

### DIFF
--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -84,7 +84,12 @@ enum InputState {
                 self = .composing
                 return .hideCandidateWindow
             case .space:
-                return .selectNextCandidate
+                // シフトが入っている場合は上に移動する
+                if event.modifierFlags.contains(.shift) {
+                    return .selectPrevCandidate
+                } else {
+                    return .selectNextCandidate
+                }
             case .navigation(let direction):
                 if direction == .right {
                     if event.modifierFlags.contains(.shift) {


### PR DESCRIPTION
macOSの標準の入力では「shift+space」を入力すると1つ上の候補を選択できる。独自ウィンドウの機能を追加したのでこの機能を追加した。