### PR TITLE
fix: 変換ウィンドウが消えるバグを修正

### DIFF
--- a/azooKeyMac/InputController/CandidateView.swift
+++ b/azooKeyMac/InputController/CandidateView.swift
@@ -120,7 +120,7 @@ class CandidatesViewController: NSViewController {
         }
 
         // ウィンドウの幅を設定（番号とパディングのための追加幅を考慮）
-        let windowWidth = min(max(maxWidth + 50, 50), 400) // 最小200px、最大400px
+        let windowWidth = max(maxWidth + 50, 400) // 最小400px
 
         var newWindowFrame = window.frame
         newWindowFrame.size.width = windowWidth


### PR DESCRIPTION
* 次のようなバグがあった
  1. IMを複数個登録
  2. azooKeyから別のIMを経由して一巡させる
  3. 再度azooKeyを起動
  4. ウィンドウが出てこなくなる
* 昨日（3da0dd）の時点では発生していないバグだったので、ここから現時点までで二分探索した結果`9e772fca7cd74e2619e11aa9620baaafb38d6cc9`が該当コミットとわかった
* デバッグを行ったところ、windowのnewFrameのwidthに400より小さい値を設定すると発生することがわかった。
* おそらくウィンドウの初期化直後に400でsetFrameしていることと関係がありそうだが、詳細は不明