### PR TITLE
feat: リッチなN-Best解の表示を実現

### DIFF
--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -794,7 +794,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = 60e4578045a54a1d80511447aa3d67f56a95731b;
+				revision = 20fe93c21d06e68fabc981653069028758f64c65;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -794,7 +794,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = 20fe93c21d06e68fabc981653069028758f64c65;
+				revision = 5a45dadd529dece73057f49c77001f347ba398aa;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac/Configs/BoolConfigItem.swift
+++ b/azooKeyMac/Configs/BoolConfigItem.swift
@@ -43,9 +43,13 @@ extension Config {
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.typeBackSlash"
     }
     /// Zenzaiを利用する設定
-    /// - warning: この設定がオンになっているとき、現在は学習をオフにしている
     struct ZenzaiIntegration: BoolConfigItem {
         static let `default` = true
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.enableZenzai"
+    }
+    /// Zenzaiを利用時、候補ウィンドウを出すタイミングでリッチな候補の要求を行う
+    struct ZenzaiRichCandidatesMode: BoolConfigItem {
+        static let `default` = true
+        static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.enableZenzaiRichCandidatesMode"
     }
 }

--- a/azooKeyMac/InputController/Actions/ClientAction.swift
+++ b/azooKeyMac/InputController/Actions/ClientAction.swift
@@ -12,6 +12,8 @@ indirect enum ClientAction {
 
     case commitMarkedText
 
+    /// スペースを押して`.selecting`に入るコマンド
+    case enterCandidateSelectionMode
     case submitSelectedCandidate
     case selectNextCandidate
     case selectPrevCandidate

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -46,7 +46,7 @@ enum InputState {
                 return .stopComposition
             case .space:
                 self = .selecting(rangeAdjusted: false)
-                return .showCandidateWindow
+                return .enterCandidateSelectionMode
             case .かな:
                 return .selectInputMode(.japanese)
             case .英数:
@@ -55,7 +55,7 @@ enum InputState {
             case .navigation(let direction):
                 if direction == .down {
                     self = .selecting(rangeAdjusted: false)
-                    return .showCandidateWindow
+                    return .enterCandidateSelectionMode
                 } else if direction == .right && event.modifierFlags.contains(.shift) {
                     self = .selecting(rangeAdjusted: true)
                     return .sequence([.moveCursorToStart, .moveCursor(1), .showCandidateWindow])

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -15,8 +15,10 @@ struct ConfigWindow: View {
     @ConfigState private var zenzaiProfile = Config.ZenzaiProfile()
     @ConfigState private var learning = Config.Learning()
     @ConfigState private var inferenceLimit = Config.ZenzaiInferenceLimit()
+    @ConfigState private var richCandidates = Config.ZenzaiRichCandidatesMode()
 
     @State private var zenzaiHelpPopover = false
+    @State private var zenzaiRichCandidatesPopover = false
     @State private var zenzaiProfileHelpPopover = false
     @State private var zenzaiInferenceLimitHelpPopover = false
 
@@ -53,6 +55,10 @@ struct ConfigWindow: View {
                     HStack {
                         Toggle("Zenzaiを有効化", isOn: $zenzai)
                         helpButton(helpContent: "Zenzaiはニューラル言語モデルを利用した最新のかな漢字変換システムです。\nMacのGPUを利用して高精度な変換を行います。\n変換エンジンはローカルで動作するため、外部との通信は不要です。", isPresented: $zenzaiHelpPopover)
+                    }
+                    HStack {
+                        Toggle("より多様な候補を提案", isOn: $richCandidates)
+                        helpButton(helpContent: "Zenzaiの利用時、複数の多様な候補を提案します。\n候補リストを表示する際に遅延が発生する可能性があります。", isPresented: $zenzaiRichCandidatesPopover)
                     }
                     HStack {
                         TextField("変換プロフィール", text: $zenzaiProfile, prompt: Text("例：田中太郎/高校生"))
@@ -95,7 +101,8 @@ struct ConfigWindow: View {
             }
             Spacer()
         }
-        .frame(width: 400, height: 300)
+        .frame(height: 300)
+        .frame(minWidth: 400, maxWidth: 600)
     }
 }
 


### PR DESCRIPTION
以下のPRで実装した新モードを適用した。このモードは変換ボタンを押して候補リストを表示する場合にのみ有効になり、これまでより若干長い時間を必要とするものの、かなりリッチな変換候補を表示してくれる。

* https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/118

* Before
![image](https://github.com/user-attachments/assets/b4e923bb-c057-4ba2-8049-99760f7ee342)
![image](https://github.com/user-attachments/assets/4f207a23-ead6-4b83-a017-468585562b12)
* After
![image](https://github.com/user-attachments/assets/62d5a770-579f-43c7-8370-46c105f1f653)
![image](https://github.com/user-attachments/assets/94710d3c-c573-4c01-91b3-ba3fdfb4f12b)
