### PR TITLE
refactor: SegmentsManagerクラスを導入し、MarkedTextの管理や変換候補の管理をここに統一した

### DIFF
--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1A41E64226E74627009B65D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41E64126E74627009B65D7 /* AppDelegate.swift */; };
 		1A41E64426E74669009B65D7 /* azooKeyMacInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41E64326E74669009B65D7 /* azooKeyMacInputController.swift */; };
 		1A41E64726E74937009B65D7 /* main.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 1A41E64626E74937009B65D7 /* main.tiff */; };
+		5502D79C2C66FE23002AAEF7 /* SegmentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5502D79B2C66FE23002AAEF7 /* SegmentsManager.swift */; };
 		551398D72BDD376800F1DB82 /* ConfigItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551398D62BDD376800F1DB82 /* ConfigItem.swift */; };
 		551398D92BDD38B700F1DB82 /* BoolConfigItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551398D82BDD38B700F1DB82 /* BoolConfigItem.swift */; };
 		551398DB2BDD39B700F1DB82 /* StringConfigItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551398DA2BDD39B700F1DB82 /* StringConfigItem.swift */; };
@@ -70,6 +71,7 @@
 		1A41E64526E7470D009B65D7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1A41E64626E74937009B65D7 /* main.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; name = main.tiff; path = azooKeyMac/main.tiff; sourceTree = SOURCE_ROOT; };
 		1A41E64826E7495A009B65D7 /* azooKeyMac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = azooKeyMac.entitlements; sourceTree = "<group>"; };
+		5502D79B2C66FE23002AAEF7 /* SegmentsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentsManager.swift; sourceTree = "<group>"; };
 		551398D62BDD376800F1DB82 /* ConfigItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigItem.swift; sourceTree = "<group>"; };
 		551398D82BDD38B700F1DB82 /* BoolConfigItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolConfigItem.swift; sourceTree = "<group>"; };
 		551398DA2BDD39B700F1DB82 /* StringConfigItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringConfigItem.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				E9C0C6F22BF5E8AE00E0EA50 /* InputMode.swift */,
 				E916C20A2BF5F81600548B7A /* azooKeyMacInputControllerHelper.swift */,
 				E97406CD2C5E546200696C66 /* CandidateView.swift */,
+				5502D79B2C66FE23002AAEF7 /* SegmentsManager.swift */,
 			);
 			path = InputController;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				551398D72BDD376800F1DB82 /* ConfigItem.swift in Sources */,
 				1A41E64426E74669009B65D7 /* azooKeyMacInputController.swift in Sources */,
 				E9C0C6F32BF5E8AE00E0EA50 /* InputMode.swift in Sources */,
+				5502D79C2C66FE23002AAEF7 /* SegmentsManager.swift in Sources */,
 				E989B4582BF4B1550085AF6D /* ClientAction.swift in Sources */,
 				551398DB2BDD39B700F1DB82 /* StringConfigItem.swift in Sources */,
 			);

--- a/azooKeyMac/InputController/Actions/UserAction.swift
+++ b/azooKeyMac/InputController/Actions/UserAction.swift
@@ -16,6 +16,20 @@ enum UserAction {
 
     enum Number {
         case one, two, three, four, five, six, seven, eight, nine, zero
+        var intValue: Int {
+            switch self {
+            case .one: 1
+            case .two: 2
+            case .three: 3
+            case .four: 4
+            case .five: 5
+            case .six: 6
+            case .seven: 7
+            case .eight: 8
+            case .nine: 9
+            case .zero: 0
+            }
+        }
 
         var inputString: String {
             switch self {

--- a/azooKeyMac/InputController/CandidateView.swift
+++ b/azooKeyMac/InputController/CandidateView.swift
@@ -6,9 +6,10 @@
 //
 
 import Cocoa
+import KanaKanjiConverterModule
 
 class CandidatesViewController: NSViewController {
-    private var candidates: [String] = []
+    private var candidates: [Candidate] = []
     private var tableView: NSTableView!
     weak var delegate: (any CandidatesViewControllerDelegate)?
     private var currentSelectedRow: Int = -1
@@ -69,7 +70,7 @@ class CandidatesViewController: NSViewController {
         configureWindowForRoundedCorners()
     }
 
-    func updateCandidates(_ candidates: [String], cursorLocation: CGPoint) {
+    func updateCandidates(_ candidates: [Candidate], cursorLocation: CGPoint) {
         showedRows = 0...8
         self.candidates = candidates
         self.currentSelectedRow = -1  // 選択をリセット
@@ -94,12 +95,12 @@ class CandidatesViewController: NSViewController {
 
         if isWithinShowedRows {
             if displayIndex > 9 {
-                displayText = " \(self.candidates[row])" // 行番号が10以上の場合、インデントを調整
+                displayText = " " + self.candidates[row].text // 行番号が10以上の場合、インデントを調整
             } else {
-                displayText = "\(displayIndex). \(self.candidates[row])"
+                displayText = "\(displayIndex). " + self.candidates[row].text
             }
         } else {
-            displayText = self.candidates[row] // showedRowsの範囲外では番号を付けない
+            displayText = self.candidates[row].text // showedRowsの範囲外では番号を付けない
         }
 
         // 数字部分と候補部分を別々に設定
@@ -132,7 +133,7 @@ class CandidatesViewController: NSViewController {
 
         // 候補の最大幅を計算
         let maxWidth = candidates.reduce(0) { maxWidth, candidate in
-            let attributedString = NSAttributedString(string: candidate, attributes: [.font: NSFont.systemFont(ofSize: 16)])
+            let attributedString = NSAttributedString(string: candidate.text, attributes: [.font: NSFont.systemFont(ofSize: 16)])
             let width = attributedString.size().width
             return max(maxWidth, width)
         }
@@ -226,7 +227,7 @@ class CandidatesViewController: NSViewController {
         let selectedRow = self.tableView.selectedRow
         if selectedRow >= 0 && selectedRow < self.candidates.count {
             let selectedCandidate = self.candidates[selectedRow]
-            delegate?.candidateSelected(selectedCandidate)
+            delegate?.candidateSubmitted(selectedCandidate)
         }
     }
 }
@@ -290,6 +291,6 @@ class CandidateTableCellView: NSTableCellView {
 }
 
 protocol CandidatesViewControllerDelegate: AnyObject {
-    func candidateSelected(_ candidate: String)
-    func candidateSelectionChanged(_ candidateString: String)
+    func candidateSubmitted(_ candidate: Candidate)
+    func candidateSelectionChanged(_ candidate: Candidate)
 }

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -100,6 +100,7 @@ enum InputState {
                             return .sequence([.moveCursorToStart, .moveCursor(1), .showCandidateWindow])
                         }
                     } else {
+                        self = .none
                         return .submitSelectedCandidate
                     }
                 } else if direction == .left && event.modifierFlags.contains(.shift) {
@@ -114,26 +115,13 @@ enum InputState {
                 }
             case .number(let num):
                 switch num {
-                case .one:
-                    return .selectNumberCandidate(1)
-                case .two:
-                    return .selectNumberCandidate(2)
-                case .three:
-                    return .selectNumberCandidate(3)
-                case .four:
-                    return .selectNumberCandidate(4)
-                case .five:
-                    return .selectNumberCandidate(5)
-                case .six:
-                    return .selectNumberCandidate(6)
-                case .seven:
-                    return .selectNumberCandidate(7)
-                case .eight:
-                    return .selectNumberCandidate(8)
-                case .nine:
-                    return .selectNumberCandidate(9)
+                case .one, .two, .three, .four, .five, .six, .seven, .eight, .nine:
+                    self = .none
+                    return .selectNumberCandidate(num.intValue)
                 case .zero:
-                    return .appendToMarkedText("0")                }
+                    self = .composing
+                    return .sequence([.submitSelectedCandidate, .appendToMarkedText("0")])
+                }
             case .かな:
                 return .selectInputMode(.japanese)
             case .英数:

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -75,7 +75,7 @@ final class SegmentsManager {
         )
     }
 
-    private var azooKeyMemoryDir: URL {
+    var azooKeyMemoryDir: URL {
         if #available(macOS 13, *) {
             URL.applicationSupportDirectory
                 .appending(path: "azooKey", directoryHint: .isDirectory)

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -1,0 +1,262 @@
+//
+//  SegmentsManager.swift
+//  azooKeyMac
+//
+//  Created by miwa on 2024/08/10.
+//
+
+import Foundation
+import InputMethodKit
+import KanaKanjiConverterModuleWithDefaultDictionary
+
+final class SegmentsManager {
+    init() {}
+
+    weak var delegate: (any SegmentManagerDelegate)?
+
+    private var composingText: ComposingText = ComposingText()
+
+    private var zenzaiEnabled: Bool {
+        Config.ZenzaiIntegration().value
+    }
+    private var liveConversionEnabled: Bool {
+        Config.LiveConversion().value
+    }
+    private var englishConversionEnabled: Bool {
+        Config.EnglishConversion().value
+    }
+    private var rawCandidates: ConversionResult?
+
+    private var selectedPrefixCandidate: Candidate?
+    private var lastOperation: Operation = .other
+
+    private enum Operation: Sendable {
+        case insert
+        case delete
+        case moveCursor
+        case other
+    }
+
+    @MainActor private var kanaKanjiConverter: KanaKanjiConverter {
+        (
+            NSApplication.shared.delegate as? AppDelegate
+        )!.kanaKanjiConverter
+    }
+
+    private func zenzaiMode(leftSideContext: String?, requestRichCandidates: Bool) -> ConvertRequestOptions.ZenzaiMode {
+        if self.zenzaiEnabled {
+            return .on(
+                weight: Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/zenz-v2-Q5_K_M.gguf", isDirectory: false),
+                inferenceLimit: Config.ZenzaiInferenceLimit().value,
+                requestRichCandidates: requestRichCandidates,
+                versionDependentMode: .v2(
+                    .init(
+                        profile: Config.ZenzaiProfile().value,
+                        leftSideContext: leftSideContext
+                    )
+                )
+            )
+        } else {
+            return .off
+        }
+    }
+
+    private func options(leftSideContext: String? = nil, requestRichCandidates: Bool = false) -> ConvertRequestOptions {
+        .withDefaultDictionary(
+            requireJapanesePrediction: false,
+            requireEnglishPrediction: false,
+            keyboardLanguage: .ja_JP,
+            englishCandidateInRoman2KanaInput: self.englishConversionEnabled,
+            learningType: Config.Learning().value.learningType,
+            memoryDirectoryURL: self.azooKeyMemoryDir,
+            sharedContainerURL: self.azooKeyMemoryDir,
+            zenzaiMode: self.zenzaiMode(leftSideContext: leftSideContext, requestRichCandidates: requestRichCandidates),
+            metadata: .init(versionString: "azooKey on macOS / α version")
+        )
+    }
+
+    private var azooKeyMemoryDir: URL {
+        if #available(macOS 13, *) {
+            URL.applicationSupportDirectory
+                .appending(path: "azooKey", directoryHint: .isDirectory)
+                .appending(path: "memory", directoryHint: .isDirectory)
+        } else {
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                .appendingPathComponent("azooKey", isDirectory: true)
+                .appendingPathComponent("memory", isDirectory: true)
+        }
+    }
+
+    @MainActor
+    func activate() {
+        self.kanaKanjiConverter.sendToDicdataStore(.setRequestOptions(options()))
+    }
+
+    @MainActor
+    func deactivate() {
+        self.kanaKanjiConverter.stopComposition()
+        self.kanaKanjiConverter.sendToDicdataStore(.setRequestOptions(options()))
+        self.kanaKanjiConverter.sendToDicdataStore(.closeKeyboard)
+        self.rawCandidates = nil
+        self.lastOperation = .other
+        self.composingText.stopComposition()
+    }
+
+    @MainActor
+    /// この入力を打ち切る
+    func stopComposition() {
+        self.composingText.stopComposition()
+        self.kanaKanjiConverter.stopComposition()
+        self.rawCandidates = nil
+        self.lastOperation = .other
+    }
+
+    @MainActor
+    /// 日本語入力自体をやめる
+    func stopJapaneseInput() {
+        self.lastOperation = .other
+        self.kanaKanjiConverter.sendToDicdataStore(.closeKeyboard)
+    }
+
+    @MainActor
+    func insertAtCursorPosition(_ string: String, inputStyle: InputStyle) {
+        self.composingText.insertAtCursorPosition(string, inputStyle: inputStyle)
+        self.lastOperation = .insert
+        self.updateRawCandidate()
+    }
+
+    @MainActor
+    func moveCursor(count: Int) {
+        _ = self.composingText.moveCursorFromCursorPosition(count: count)
+        if self.composingText.convertTargetCursorPosition == 0 {
+            _ = self.composingText.moveCursorFromCursorPosition(count: 1)
+        }
+        self.lastOperation = .moveCursor
+        self.updateRawCandidate()
+    }
+
+    @MainActor
+    func deleteBackwardFromCursorPosition(count: Int = 1) {
+        self.composingText.deleteBackwardFromCursorPosition(count: count)
+        self.lastOperation = .delete
+        self.updateRawCandidate()
+    }
+
+    @MainActor
+    func moveCursorToStart() {
+        _ = self.composingText.moveCursorFromCursorPosition(count: -self.composingText.convertTargetCursorPosition)
+        self.updateRawCandidate()
+    }
+
+    var candidates: [Candidate]? {
+        self.rawCandidates?.mainResults
+    }
+
+    var convertTarget: String {
+        self.composingText.convertTarget
+    }
+
+    var isEmpty: Bool {
+        self.composingText.isEmpty
+    }
+
+    @MainActor private func updateRawCandidate(requestRichCandidates: Bool = false) {
+        // 不要
+        if composingText.isEmpty {
+            self.rawCandidates = nil
+            self.kanaKanjiConverter.stopComposition()
+            return
+        }
+
+        let prefixComposingText = self.composingText.prefixToCursorPosition()
+        let leftSideContext = self.delegate?.getLeftSideContext(maxCount: 30).map {
+            var last = $0.split(separator: "\n", omittingEmptySubsequences: false).last ?? $0[...]
+            // 空白を削除する
+            while last.first?.isWhitespace ?? false {
+                last = last.dropFirst()
+            }
+            while last.last?.isWhitespace ?? false {
+                last = last.dropLast()
+            }
+            return String(last)
+        }
+        let result = self.kanaKanjiConverter.requestCandidates(prefixComposingText, options: options(leftSideContext: leftSideContext, requestRichCandidates: requestRichCandidates))
+        self.rawCandidates = result
+    }
+
+    @MainActor func update(requestRichCandidates: Bool) {
+        self.updateRawCandidate(requestRichCandidates: true)
+    }
+
+    @MainActor func candidateCommited(_ candidate: Candidate) {
+        self.kanaKanjiConverter.setCompletedData(candidate)
+        self.kanaKanjiConverter.updateLearningData(candidate)
+        self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
+
+        if !self.composingText.isEmpty {
+            self.updateRawCandidate()
+        }
+    }
+
+    struct MarkedText: Sendable, Equatable, Hashable, Sequence {
+        enum FocusState: Sendable, Equatable, Hashable {
+            case focused
+            case unfocused
+            case none
+        }
+
+        struct Element: Sendable, Equatable, Hashable {
+            var content: String
+            var focus: FocusState
+        }
+        var text: [Element]
+
+        var selectionRange: NSRange
+
+        func makeIterator() -> Array<Element>.Iterator {
+            return text.makeIterator()
+        }
+    }
+
+    func requestUpdateMarkedText(selectedPrefixCandidate: Candidate) {
+        self.selectedPrefixCandidate = selectedPrefixCandidate
+    }
+
+    func getCurrentMarkedText(inputState: InputState) -> MarkedText {
+        switch inputState {
+        case .none, .composing:
+            let text = if self.lastOperation == .delete {
+                // 削除のあとは常にひらがなを示す
+                self.composingText.convertTarget
+            } else if self.liveConversionEnabled,
+                self.composingText.convertTarget.count > 1,
+            let firstCandidate = self.rawCandidates?.mainResults.first {
+                // それ以外の場合、ライブ変換が有効なら
+                firstCandidate.text
+            } else {
+                // それ以外
+                self.composingText.convertTarget
+            }
+            return MarkedText(text: [.init(content: text, focus: .none)], selectionRange: .notFound)
+        case .selecting:
+            if let selectedPrefixCandidate {
+                var afterComposingText = self.composingText
+                afterComposingText.prefixComplete(correspondingCount: selectedPrefixCandidate.correspondingCount)
+
+                return MarkedText(
+                    text: [
+                        .init(content: selectedPrefixCandidate.text, focus: .focused),
+                        .init(content: afterComposingText.convertTarget, focus: .unfocused)
+                    ],
+                    selectionRange: NSRange(location: selectedPrefixCandidate.text.count, length: 0)
+                )
+            } else {
+                return MarkedText(text: [.init(content: self.composingText.convertTarget, focus: .none)], selectionRange: .notFound)
+            }
+        }
+    }
+}
+
+protocol SegmentManagerDelegate: AnyObject {
+    func getLeftSideContext(maxCount: Int) -> String?
+}

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -14,7 +14,7 @@ let applicationLogger: Logger = Logger(subsystem: "dev.ensan.inputmethod.azooKey
 
 @objc(azooKeyMacInputController)
 class azooKeyMacInputController: IMKInputController {
-    private var segmentsManager: SegmentsManager
+    var segmentsManager: SegmentsManager
     private var inputState: InputState = .none
     private var directMode = false
     var zenzaiEnabled: Bool {

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -294,7 +294,6 @@ class azooKeyMacInputController: IMKInputController {
 
 extension azooKeyMacInputController: CandidatesViewControllerDelegate {
     @MainActor func candidateSubmitted(_ candidate: Candidate) {
-        self.inputState = .none
         if let client = self.client() {
             client.insertText(candidate.text, replacementRange: NSRange(location: NSNotFound, length: 0))
             // アプリケーションサポートのディレクトリを準備しておく

--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -64,23 +64,10 @@ extension azooKeyMacInputController {
     }
 
     // MARK: - Application Support Directory
-
-    var azooKeyMemoryDir: URL {
-        if #available(macOS 13, *) {
-            URL.applicationSupportDirectory
-                .appending(path: "azooKey", directoryHint: .isDirectory)
-                .appending(path: "memory", directoryHint: .isDirectory)
-        } else {
-            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-                .appendingPathComponent("azooKey", isDirectory: true)
-                .appendingPathComponent("memory", isDirectory: true)
-        }
-    }
-
     func prepareApplicationSupportDirectory() {
         do {
-            applicationLogger.info("\(#line, privacy: .public): Applicatiion Support Directory Path: \(self.azooKeyMemoryDir, privacy: .public)")
-            try FileManager.default.createDirectory(at: self.azooKeyMemoryDir, withIntermediateDirectories: true)
+            applicationLogger.info("\(#line, privacy: .public): Applicatiion Support Directory Path: \(self.segmentsManager.azooKeyMemoryDir, privacy: .public)")
+            try FileManager.default.createDirectory(at: self.segmentsManager.azooKeyMemoryDir, withIntermediateDirectories: true)
         } catch {
             applicationLogger.error("\(#line, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }


### PR DESCRIPTION
これまで、入力状態の管理はazooKeyInputControllerで引き受けていたが
azooKeyInputControllerは様々なタスクを持ったクラスであり、やや複雑化していた。そこで役割の一部をSegmentsControllerとして新たに分割し、ここでComposingTextやMarkedText、Candidatesを管理することにした。