### PR TITLE
feat: 単文節の変換を優先的に表示し、そのあとで入力全体の変換候補を出すように変更

### DIFF
--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = 5a45dadd529dece73057f49c77001f347ba398aa;
+				revision = 472fe19d410f16ad053164758d9610689950fd3e;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = a13507316a20eb25e645995873db946032380367;
+				revision = 172509a7dba4eec0b9664051db6a575d8b832de5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = 472fe19d410f16ad053164758d9610689950fd3e;
+				revision = a13507316a20eb25e645995873db946032380367;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac/InputController/Actions/ClientAction.swift
+++ b/azooKeyMac/InputController/Actions/ClientAction.swift
@@ -7,10 +7,10 @@ indirect enum ClientAction {
     case hideCandidateWindow
     case appendToMarkedText(String)
     case removeLastMarkedText
-    case moveCursorToStart
-    case moveCursor(Int)
 
     case commitMarkedText
+    /// Shift+←→で選択範囲をエディットするコマンド
+    case editSegment(Int)
 
     /// スペースを押して`.selecting`に入るコマンド
     case enterCandidateSelectionMode

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -98,6 +98,7 @@ final class SegmentsManager {
         self.kanaKanjiConverter.sendToDicdataStore(.setRequestOptions(options()))
         self.kanaKanjiConverter.sendToDicdataStore(.closeKeyboard)
         self.rawCandidates = nil
+        self.selectedPrefixCandidate = nil
         self.lastOperation = .other
         self.composingText.stopComposition()
     }
@@ -108,12 +109,15 @@ final class SegmentsManager {
         self.composingText.stopComposition()
         self.kanaKanjiConverter.stopComposition()
         self.rawCandidates = nil
+        self.selectedPrefixCandidate = nil
         self.lastOperation = .other
     }
 
     @MainActor
     /// 日本語入力自体をやめる
     func stopJapaneseInput() {
+        self.selectedPrefixCandidate = nil
+        self.rawCandidates = nil
         self.lastOperation = .other
         self.kanaKanjiConverter.sendToDicdataStore(.closeKeyboard)
     }
@@ -185,7 +189,7 @@ final class SegmentsManager {
     }
 
     @MainActor func update(requestRichCandidates: Bool) {
-        self.updateRawCandidate(requestRichCandidates: true)
+        self.updateRawCandidate(requestRichCandidates: requestRichCandidates)
     }
 
     @MainActor func candidateCommited(_ candidate: Candidate) {

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -153,7 +153,14 @@ final class SegmentsManager {
     }
 
     var candidates: [Candidate]? {
-        self.rawCandidates?.mainResults
+        if let rawCandidates {
+            let seenAsFirstClauseResults = rawCandidates.firstClauseResults.mapSet(transform: \.text)
+            return rawCandidates.firstClauseResults + rawCandidates.mainResults.filter {
+                !seenAsFirstClauseResults.contains($0.text)
+            }
+        } else {
+            return nil
+        }
     }
 
     var convertTarget: String {

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -164,11 +164,13 @@ final class SegmentsManager {
 
     @MainActor
     func deleteBackwardFromCursorPosition(count: Int = 1) {
-        self.composingText.deleteBackwardFromCursorPosition(count: count)
-        if self.composingText.isAtStartIndex {
+        if !self.composingText.isAtEndIndex {
             // 右端に持っていく
-            _ = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTarget.count)
+            _ = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
+            // 一度segmentの編集状態もリセットにする
+            self.didExperienceSegmentEdition = false
         }
+        self.composingText.deleteBackwardFromCursorPosition(count: count)
         self.lastOperation = .delete
         self.updateRawCandidate()
     }

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -33,7 +33,7 @@ final class SegmentsManager {
     private enum Operation: Sendable {
         case insert
         case delete
-        case moveCursor
+        case editSegment
         case other
     }
 
@@ -130,12 +130,19 @@ final class SegmentsManager {
     }
 
     @MainActor
-    func moveCursor(count: Int) {
-        _ = self.composingText.moveCursorFromCursorPosition(count: count)
-        if self.composingText.convertTargetCursorPosition == 0 {
-            _ = self.composingText.moveCursorFromCursorPosition(count: 1)
+    func editSegment(count: Int) {
+        if count > 0 {
+            if self.composingText.isAtEndIndex {
+                // 現在のカーソルが右端にある場合、左端の次に移動する
+                _ = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTargetCursorPosition - count)
+            } else {
+                // それ以外の場合、右に広げる
+                _ = self.composingText.moveCursorFromCursorPosition(count: count)
+            }
+        } else {
+            _ = self.composingText.moveCursorFromCursorPosition(count: count)
         }
-        self.lastOperation = .moveCursor
+        self.lastOperation = .editSegment
         self.updateRawCandidate()
     }
 

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -178,10 +178,15 @@ final class SegmentsManager {
     var candidates: [Candidate]? {
         if let rawCandidates {
             if !self.didExperienceSegmentEdition {
-                // 変換範囲がエディットされていない場合
-                let seenAsFirstClauseResults = rawCandidates.firstClauseResults.mapSet(transform: \.text)
-                return rawCandidates.firstClauseResults + rawCandidates.mainResults.filter {
-                    !seenAsFirstClauseResults.contains($0.text)
+                if rawCandidates.firstClauseResults.lazy.map({$0.correspondingCount}).max() == rawCandidates.mainResults.lazy.map({$0.correspondingCount}).max() {
+                    // firstClauseCandidateがmainResultsと同じサイズの場合は、何もしない方が良い
+                    return rawCandidates.mainResults
+                } else {
+                    // 変換範囲がエディットされていない場合
+                    let seenAsFirstClauseResults = rawCandidates.firstClauseResults.mapSet(transform: \.text)
+                    return rawCandidates.firstClauseResults + rawCandidates.mainResults.filter {
+                        !seenAsFirstClauseResults.contains($0.text)
+                    }
                 }
             } else {
                 return rawCandidates.mainResults

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -205,10 +205,9 @@ class azooKeyMacInputController: IMKInputController {
             self.hideCandidateWindow()
             self.segmentsManager.insertAtCursorPosition(string, inputStyle: .roman2kana)
             self.refreshMarkedText()
-        case .moveCursor(let value):
-            self.segmentsManager.moveCursor(count: value)
-        case .moveCursorToStart:
-            self.segmentsManager.moveCursorToStart()
+        case .editSegment(let count):
+            self.segmentsManager.editSegment(count: count)
+            self.showCandidateWindow()
         case .commitMarkedText:
             let markedText = self.segmentsManager.getCurrentMarkedText(inputState: self.inputState)
             let text = markedText.reduce(into: "") {$0.append(contentsOf: $1.content)}
@@ -304,7 +303,7 @@ extension azooKeyMacInputController: CandidatesViewControllerDelegate {
                 self.candidatesViewController.clearCandidates()
                 self.hideCandidateWindow()
             } else {
-                self.inputState = .selecting(rangeAdjusted: false)
+                self.inputState = .selecting
                 client.setMarkedText(
                     NSAttributedString(string: self.segmentsManager.convertTarget, attributes: [:]),
                     selectionRange: .notFound,

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -213,7 +213,7 @@ class azooKeyMacInputController: IMKInputController {
             let text = markedText.reduce(into: "") {$0.append(contentsOf: $1.content)}
             client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
             if let candidate = self.segmentsManager.candidates?.first(where: {$0.text == text}) {
-                self.segmentsManager.candidateCommited(candidate)
+                self.segmentsManager.prefixCandidateCommited(candidate)
             }
             self.segmentsManager.stopComposition()
             self.hideCandidateWindow()
@@ -296,7 +296,7 @@ extension azooKeyMacInputController: CandidatesViewControllerDelegate {
         if let client = self.client() {
             client.insertText(candidate.text, replacementRange: NSRange(location: NSNotFound, length: 0))
             // アプリケーションサポートのディレクトリを準備しておく
-            self.segmentsManager.candidateCommited(candidate)
+            self.segmentsManager.prefixCandidateCommited(candidate)
 
             if self.segmentsManager.isEmpty {
                 self.segmentsManager.stopComposition()


### PR DESCRIPTION
これまでazooKey on macOSではスマホ版の挙動に倣い、第一候補として入力全体を変換した候補を表示していた。しかし、デスクトップ環境のIMEで標準的な挙動は第一候補として単文節の変換を出すものである。そこで、これに倣って単文節の変換候補を優先的に表示し、そのあとで全体の変換を差し込むように修正した
![image](https://github.com/user-attachments/assets/7557b0aa-2dd4-4ede-9716-2a0e018b1d41)
