### PR TITLE
feat: 「プレビュー」の状態を追加し、composingとselectingの間でここに遷移するように変更

### DIFF
--- a/azooKeyMac/InputController/Actions/ClientAction.swift
+++ b/azooKeyMac/InputController/Actions/ClientAction.swift
@@ -1,6 +1,6 @@
 import InputMethodKit
 
-indirect enum ClientAction {
+enum ClientAction {
     case `consume`
     case `fallthrough`
     case showCandidateWindow
@@ -12,6 +12,9 @@ indirect enum ClientAction {
     /// Shift+←→で選択範囲をエディットするコマンド
     case editSegment(Int)
 
+    /// previwingに入るコマンド
+    case enterFirstCandidatePreviewMode
+
     /// スペースを押して`.selecting`に入るコマンド
     case enterCandidateSelectionMode
     case submitSelectedCandidate
@@ -20,6 +23,14 @@ indirect enum ClientAction {
     case selectNumberCandidate(Int)
 
     case selectInputMode(InputMode)
+    case commitMarkedTextAndSelectInputMode(InputMode)
+    /// MarkedTextを確定して、さらに追加で入力する
+    case commitMarkedTextAndAppendToMarkedText(String)
+
+    /// 現在選ばれている候補を確定して、さらに追加で入力する
+    ///  - note:`commitMarkedTextAndAppendToMarkedText`はMarkedText全体を一度に確定するが、`submitSelectedCandidateAndAppendToMarkedText`の場合は部分的に確定されることがあるという違いがある
+    case submitSelectedCandidateAndAppendToMarkedText(String)
+    case submitSelectedCandidateAndEnterFirstCandidatePreviewMode
 
     case stopComposition
 
@@ -27,6 +38,13 @@ indirect enum ClientAction {
         case roman
         case japanese
     }
+}
 
-    case sequence([ClientAction])
+
+enum ClientActionCallback {
+    case `fallthrough`
+    case transition(InputState)
+    /// 
+    case basedOnBackspace(ifIsEmpty: InputState, ifIsNotEmpty: InputState)
+    case basedOnSubmitCandidate(ifIsEmpty: InputState, ifIsNotEmpty: InputState)
 }

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -167,6 +167,7 @@ final class SegmentsManager {
         self.lastOperation = .editSegment
         self.didExperienceSegmentEdition = true
         self.shouldShowCandidateWindow = true
+        self.selectionIndex = nil
         self.updateRawCandidate()
     }
 


### PR DESCRIPTION
ライブ変換のない一般的なIMEでは、入力して（composing）スペースを押すと「最も優れた変換候補がプレビューされる」という挙動（previewing）が発生し、もう一度スペースを押して初めて変換候補の一覧が出てくる（selecting）。一方、現在のazooKey on macOSの実装はそうなっておらず、composingからいきなりselectingに遷移している。

そこで、ライブ変換がオフになっている場合、composingから1度目のスペースでpreviewingに遷移し、次にselectingに遷移するように変更した。このpreviwingの状態はこの後候補を確定するたびに戻ってくるものである。

このpreviewingを追加したことにより、出来上がった候補を一度確認してからEnterを押して確定する通常の利用フローがそのまま使えるようになり、azooKeyを利用する際の体験が大きく向上した。

なお、この機能の実現のため、いくつかの追加リファクタリングを入れた。
* `SegmentsManager`の側で候補の選択状態までを担うように変更した。これによって`SegmentsManager`が候補ウィンドウに関するほとんどを管理できるようになる。
* `InputState`における`event`関数をimmutableにした。これまでこの関数は自身を変更する`mutating`メソッドだったが、本来的に処理の結果がわからないと遷移が定まらないケースがあるため、やや苦しい実装を招いていた。immutableにして、遷移をコールバックの形で返す実装としたことによって、処理がシンプルに書けるようになり、扱いやすくなったと思われる。
* `ClientAction`として`sequence`を廃止した。`sequence`はケースを増やさずに合成的な動作を実現する上で有用であるものの、不用意な自由度の高さがあるため、バグの原因となる。一旦全て展開して実装し直し、この後様子を見ていくこととした。