### PR TITLE
chore: install.shでxcodeprojファイルを利用するよう変更

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,10 +33,10 @@ fi
 # Check if xcpretty is installed
 if command -v xcpretty &> /dev/null
 then
-    xcodebuild -workspace azooKeyMac.xcodeproj/project.xcworkspace -scheme azooKeyMac clean archive -archivePath build/archive.xcarchive | xcpretty
+    xcodebuild -project azooKeyMac.xcodeproj -scheme azooKeyMac clean archive -archivePath build/archive.xcarchive | xcpretty
 else
     echo "xcpretty could not be found. Proceeding without xcpretty."
-    xcodebuild -workspace azooKeyMac.xcodeproj/project.xcworkspace -scheme azooKeyMac clean archive -archivePath build/archive.xcarchive
+    xcodebuild -project azooKeyMac.xcodeproj -scheme azooKeyMac clean archive -archivePath build/archive.xcarchive
 fi
 
 sudo rm -rf /Library/Input\ Methods/azooKeyMac.app


### PR DESCRIPTION
`install.sh` で以下の2点を変更しております。

1. `.xcworkspace` を `.xcodeproj` に変更

`.xcworkspace` が指定されていたのですがGitになかったことと、 `.xcodeproj` でもビルドが通るようでしたので変更してみました。

2. インストール先をグローバルではなく、ユーザ毎の `~/Library/Input Methods` に変更

ちょっと検証不足な面もあるのですが、自分の環境（macOS Sonoma 14.3.1）ではグローバルインストールでは環境設定に出てきませんでした（再起動など必要でしょうか？）。
ローカルですと無事に出てきましたので変更してみました。
なお、この場合は手元でazookeyのバイナリを別途実行しておかないと作動しませんでした。グローバルの場合は自動的に立ち上がる形でしょうか？
また、他の人の開発にも影響するかと思いますので、指示していただいたらコミットを外します（別コミットにしております。

いずれも何か見落としなどあるかと思いますので、ぜひご指摘ください。
よろしくお願いいたします。