### PR TITLE
27 feature macのショートカットキーに対応

### DIFF
--- a/azooKeyMac/InputController/Actions/UserAction.swift
+++ b/azooKeyMac/InputController/Actions/UserAction.swift
@@ -10,6 +10,7 @@ enum UserAction {
     case navigation(NavigationDirection)
     case function(Function)
     case number(Number)
+    case editSegment(Int)
 
     enum NavigationDirection {
         case up, down, right, left

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -32,6 +32,14 @@ enum InputMode {
             } else {
                 return .unknown
             }
+        case 0x03: // Control + f
+            if event.modifierFlags.contains(.control) {
+                return .navigation(.right)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
         case 0x22: // Control + i
             if event.modifierFlags.contains(.control) {
                 return .editSegment(-1)  // Shift segment cursor left

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -32,6 +32,22 @@ enum InputMode {
             } else {
                 return .unknown
             }
+        case 0x22: // Control + i
+            if event.modifierFlags.contains(.control) {
+                return .editSegment(-1)  // Shift segment cursor left
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
+        case 0x1F: // Control + o
+            if event.modifierFlags.contains(.control) {
+                return .editSegment(1)  // Shift segment cursor right
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
         case 36: // Enter
             return .enter
         case 48: // Tab

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -56,6 +56,22 @@ enum InputMode {
             } else {
                 return .unknown
             }
+        case 0x26: // Control + j
+            if event.modifierFlags.contains(.control) {
+                return .function(.six)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
+        case 0x28: // Control + k
+            if event.modifierFlags.contains(.control) {
+                return .function(.seven)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
         case 36: // Enter
             return .enter
         case 48: // Tab

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -16,6 +16,22 @@ enum InputMode {
             } else {
                 return .unknown
             }
+        case 0x23: // Control + p
+            if event.modifierFlags.contains(.control) {
+                return .navigation(.up)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
+        case 0x2D: // Control + n
+            if event.modifierFlags.contains(.control) {
+                return .navigation(.down)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(KeyMap.h2zMap(text))
+            } else {
+                return .unknown
+            }
         case 36: // Enter
             return .enter
         case 48: // Tab

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -35,7 +35,7 @@ enum InputState {
                 } else {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
-            case .unknown, .navigation, .backspace, .enter, .escape, .function:
+            case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment:
                 return (.fallthrough, .fallthrough)
             }
         case .composing:
@@ -80,6 +80,8 @@ enum InputState {
                     // ナビゲーションはハンドルしてしまう
                     return (.consume, .fallthrough)
                 }
+            case .editSegment(let count):
+                return (.editSegment(count), .transition(.selecting))
             case .unknown:
                 return (.fallthrough, .fallthrough)
             }
@@ -121,6 +123,8 @@ enum InputState {
                     // ナビゲーションはハンドルしてしまう
                     return (.consume, .fallthrough)
                 }
+            case .editSegment(let count):
+                return (.editSegment(count), .transition(.selecting))
             case .unknown:
                 return (.fallthrough, .fallthrough)
             }
@@ -182,6 +186,8 @@ enum InputState {
                 case .zero:
                     return (.submitSelectedCandidateAndAppendToMarkedText(num.inputString), .transition(.composing))
                 }
+            case .editSegment(let count):
+                return (.editSegment(count), .transition(.selecting))
             case .かな:
                 return (.selectInputMode(.japanese), .fallthrough)
             case .英数:


### PR DESCRIPTION
# emacsのショートカットキー対応

実装

```
変換の選択
ctrl + p : 上
ctrl + n : 下
変換区切りの変更
ctrl + i : 区切りを左に
ctrl + o : 区切りを右に
ctrl + f : 変換の選択を右に
ctrl + b : 変換の選択を左に
かな英字変換
ctrl + j : ひらがな
ctrl + k : カタカナ
```

## 未対応

現状のFnキーでの変換でも対応していないので、優先度が低いと判断して未実装

```
ctrl + l : 全角英字 ｚｅｎｋａｋｕｅｉｊｉ
ctrl + ; : 半角英字 hankakueiji
```