### PR TITLE
fix: Zenzaiがなくてもユーザ辞書が動作するように修正

### DIFF
--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
 			requirement = {
 				kind = revision;
-				revision = 8cf7aabf630f71f3b3cb617e959e4ea2ea01f5a1;
+				revision = 552d6d803be4933be0b4dd627d56869213ca8b7a;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -248,6 +248,7 @@ final class SegmentsManager {
         self.kanaKanjiConverter.sendToDicdataStore(.importDynamicUserDict(userDictionary.items.map {
             .init(word: $0.word, ruby: $0.reading.toKatakana(), cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
         }))
+        self.appendDebugMessage("userDictionaryCount: \(self.userDictionary.items.count)")
 
         let prefixComposingText = self.composingText.prefixToCursorPosition()
         let leftSideContext = self.delegate?.getLeftSideContext(maxCount: 30).map {


### PR DESCRIPTION
以下を含むバージョンを取り込んで、挙動を修正
* https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/136
* https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/139

そのほか、以下の変更も含まれる。
* https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/134
* https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/137