### PR TITLE
番号付きの候補リスト幅を少し広くする

### DIFF
--- a/azooKeyMac/InputController/CandidateView.swift
+++ b/azooKeyMac/InputController/CandidateView.swift
@@ -145,7 +145,7 @@ class CandidatesViewController: NSViewController {
         // ウィンドウの幅を設定（番号とパディングのための追加幅を考慮）
         // 20 = corner radius * 2
         let windowWidth = if self.showCandidateIndex {
-            maxWidth + 32
+            maxWidth + 48
         } else {
             maxWidth + 20
         }


### PR DESCRIPTION
候補リストのデフォルト幅が少し狭いようだったので広くしました。

macOSの設定次第の可能性もありますので、指摘ください。
（なお、Discordのスクリーンショットでは同様に[狭くなっている方もいる](https://discord.com/channels/1166734354492440638/1219932948799946792/1289491409702879242) ようです）

### Before

<img width="83" alt="azookey_before" src="https://github.com/user-attachments/assets/d253433e-2058-4b1b-b716-554d74533090">

### After

<img width="83" alt="azookey_after" src="https://github.com/user-attachments/assets/20f71e8b-79c1-4746-8550-e376bd71046c">
