### PR TITLE
security: OpenAI APIキーをkeychainに保存するように変更

### DIFF
--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -34,12 +34,12 @@
 		55E0A5C02BA8AE3200FACF50 /* SwiftUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 55E0A5BF2BA8AE3200FACF50 /* SwiftUtils */; };
 		55EA62E22BD6BF900056B5BA /* ConfigWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EA62E12BD6BF900056B5BA /* ConfigWindow.swift */; };
 		E916C20B2BF5F81600548B7A /* azooKeyMacInputControllerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E916C20A2BF5F81600548B7A /* azooKeyMacInputControllerHelper.swift */; };
+		E92B825A2CAE4B6A00D3C2D6 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92B82592CAE4B6A00D3C2D6 /* KeychainHelper.swift */; };
 		E92E50732CA83F9B00403D75 /* OpenAIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92E50722CA83F9B00403D75 /* OpenAIClient.swift */; };
 		E96A5BC72BF4B28400AEAB72 /* InputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96A5BC62BF4B28400AEAB72 /* InputState.swift */; };
 		E97406CE2C5E546200696C66 /* CandidateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97406CD2C5E546200696C66 /* CandidateView.swift */; };
 		E989B4562BF4B1130085AF6D /* UserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E989B4552BF4B1130085AF6D /* UserAction.swift */; };
 		E989B4582BF4B1550085AF6D /* ClientAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E989B4572BF4B1550085AF6D /* ClientAction.swift */; };
-		E98E5A0C2CABD2440046FB40 /* UserDictionaryEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CE92522C9FC08100C38E1B /* UserDictionaryEditorWindow.swift */; };
 		E9B127FB2CA90775007AFF33 /* SuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B127FA2CA90775007AFF33 /* SuggestionView.swift */; };
 		E9C0C6F32BF5E8AE00E0EA50 /* InputMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0C6F22BF5E8AE00E0EA50 /* InputMode.swift */; };
 /* End PBXBuildFile section */
@@ -92,6 +92,7 @@
 		55CE92522C9FC08100C38E1B /* UserDictionaryEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDictionaryEditorWindow.swift; sourceTree = "<group>"; };
 		55EA62E12BD6BF900056B5BA /* ConfigWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigWindow.swift; sourceTree = "<group>"; };
 		E916C20A2BF5F81600548B7A /* azooKeyMacInputControllerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = azooKeyMacInputControllerHelper.swift; sourceTree = "<group>"; };
+		E92B82592CAE4B6A00D3C2D6 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		E92E50722CA83F9B00403D75 /* OpenAIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIClient.swift; sourceTree = "<group>"; };
 		E96A5BC62BF4B28400AEAB72 /* InputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputState.swift; sourceTree = "<group>"; };
 		E97406CD2C5E546200696C66 /* CandidateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CandidateView.swift; sourceTree = "<group>"; };
@@ -220,6 +221,7 @@
 		55A9C54C2BA84945007F6F02 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				E92B82592CAE4B6A00D3C2D6 /* KeychainHelper.swift */,
 				55A9C54D2BA84951007F6F02 /* NSRange.swift */,
 			);
 			path = Extensions;
@@ -415,6 +417,7 @@
 				E9B127FB2CA90775007AFF33 /* SuggestionView.swift in Sources */,
 				E97406CE2C5E546200696C66 /* CandidateView.swift in Sources */,
 				E916C20B2BF5F81600548B7A /* azooKeyMacInputControllerHelper.swift in Sources */,
+				E92B825A2CAE4B6A00D3C2D6 /* KeychainHelper.swift in Sources */,
 				557D35E12BB1C22100877564 /* KeyMap.swift in Sources */,
 				E96A5BC72BF4B28400AEAB72 /* InputState.swift in Sources */,
 				55EA62E22BD6BF900056B5BA /* ConfigWindow.swift in Sources */,

--- a/azooKeyMac/Configs/StringConfigItem.swift
+++ b/azooKeyMac/Configs/StringConfigItem.swift
@@ -23,6 +23,16 @@ extension StringConfigItem {
 extension Config {
     struct OpenAiApiKey: StringConfigItem {
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.OpenAiApiKey"
+
+        // keychainで保存
+        var value: String {
+            get {
+                KeychainHelper.shared.read(key: Self.key) ?? ""
+            }
+            nonmutating set {
+                KeychainHelper.shared.save(key: Self.key, value: newValue)
+            }
+        }
     }
 }
 

--- a/azooKeyMac/Configs/StringConfigItem.swift
+++ b/azooKeyMac/Configs/StringConfigItem.swift
@@ -27,10 +27,10 @@ extension Config {
         // keychainで保存
         var value: String {
             get {
-                KeychainHelper.shared.read(key: Self.key) ?? ""
+                KeychainHelper.read(key: Self.key) ?? ""
             }
             nonmutating set {
-                KeychainHelper.shared.save(key: Self.key, value: newValue)
+                KeychainHelper.save(key: Self.key, value: newValue)
             }
         }
     }

--- a/azooKeyMac/Extensions/KeychainHelper.swift
+++ b/azooKeyMac/Extensions/KeychainHelper.swift
@@ -1,0 +1,62 @@
+//
+//  KeychainHelper.swift
+//  azooKeyMac
+//
+//  Created by 高橋直希 on 2024/10/03.
+//
+
+import Foundation
+import Security
+
+class KeychainHelper {
+    static let shared = KeychainHelper()
+
+    private init() {}
+
+    func save(key: String, value: String) {
+        guard let data = value.data(using: .utf8) else {
+            print("StringをDataに変換する際にエラーが発生しました")
+            return
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+
+        // 既存のデータがあれば削除
+        SecItemDelete(query as CFDictionary)
+
+        // 新しいデータを追加
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func read(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+
+        if status == errSecSuccess, let data = dataTypeRef as? Data {
+
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        return nil
+    }
+
+    func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/azooKeyMac/Extensions/KeychainHelper.swift
+++ b/azooKeyMac/Extensions/KeychainHelper.swift
@@ -8,12 +8,8 @@
 import Foundation
 import Security
 
-class KeychainHelper {
-    static let shared = KeychainHelper()
-
-    private init() {}
-
-    func save(key: String, value: String) {
+enum KeychainHelper {
+    static func save(key: String, value: String) {
         guard let data = value.data(using: .utf8) else {
             print("StringをDataに変換する際にエラーが発生しました")
             return
@@ -32,7 +28,7 @@ class KeychainHelper {
         SecItemAdd(query as CFDictionary, nil)
     }
 
-    func read(key: String) -> String? {
+    static func read(key: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
@@ -44,14 +40,13 @@ class KeychainHelper {
         let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
 
         if status == errSecSuccess, let data = dataTypeRef as? Data {
-
             return String(decoding: data, as: UTF8.self)
         }
 
         return nil
     }
 
-    func delete(key: String) {
+    static func delete(key: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -112,7 +112,7 @@ struct ConfigWindow: View {
                         Toggle("（開発者用）デバッグウィンドウを有効化", isOn: $debugWindow)
                         Toggle("OpenAI APIキーの利用", isOn: $enableOpenAiApiKey)
                         HStack {
-                            TextField("OpenAI API", text: $openAiApiKey, prompt: Text("例:sk-xxxxxxxxxxx"))
+                            SecureField("OpenAI API", text: $openAiApiKey, prompt: Text("例:sk-xxxxxxxxxxx"))
                             helpButton(
                                 helpContent: "OpenAI APIキーはローカルのみで管理され、外部に公開されることはありません。生成の際にAPIを利用するため、課金が発生します。",
                                 isPresented: $openAiApiKeyPopover


### PR DESCRIPTION
- OpenAI APIキーの保存をUserDefaultsからKeychainに変更
- ConfigのAPIキーの入力フィールドをSecureFieldに変更
![CleanShot 2024-10-03 at 12 46 54](https://github.com/user-attachments/assets/24cb091c-8231-4a5f-bae1-5d3999f4a7be)