### PR TITLE
fix: Suggestのショートカットを既存のキーバインドと競合しないctrl + sに変更

### DIFF
--- a/azooKeyMac/InputController/Actions/UserAction.swift
+++ b/azooKeyMac/InputController/Actions/UserAction.swift
@@ -12,7 +12,7 @@ enum UserAction {
     case function(Function)
     case number(Number)
     case editSegment(Int)
-    case suggest
+    case suggest(Bool)
 
     enum NavigationDirection {
         case up, down, right, left

--- a/azooKeyMac/InputController/Actions/UserAction.swift
+++ b/azooKeyMac/InputController/Actions/UserAction.swift
@@ -12,7 +12,7 @@ enum UserAction {
     case function(Function)
     case number(Number)
     case editSegment(Int)
-    case suggest(Bool)
+    case suggest
 
     enum NavigationDirection {
         case up, down, right, left

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -74,7 +74,7 @@ enum InputMode {
             }
         case 0x01: // Control + s
             if event.modifierFlags.contains(.control) {
-                return .suggest
+                return .suggest(Config.EnableOpenAiApiKey().value)
             } else if let text = event.characters, isPrintable(text) {
                 return .input(KeyMap.h2zMap(text))
             } else {

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -74,7 +74,7 @@ enum InputMode {
             }
         case 0x01: // Control + s
             if event.modifierFlags.contains(.control) {
-                return .suggest(Config.EnableOpenAiApiKey().value)
+                return .suggest
             } else if let text = event.characters, isPrintable(text) {
                 return .input(KeyMap.h2zMap(text))
             } else {

--- a/azooKeyMac/InputController/InputMode.swift
+++ b/azooKeyMac/InputController/InputMode.swift
@@ -72,7 +72,7 @@ enum InputMode {
             } else {
                 return .unknown
             }
-        case 0x0E: // Control + e
+        case 0x01: // Control + s
             if event.modifierFlags.contains(.control) {
                 return .suggest
             } else if let text = event.characters, isPrintable(text) {

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -13,7 +13,8 @@ enum InputState {
         _ event: NSEvent!,
         userAction: UserAction,
         liveConversionEnabled: Bool,
-        enableDebugWindow: Bool
+        enableDebugWindow: Bool,
+        enableSuggestion: Bool
     ) -> (ClientAction, ClientActionCallback) {
         if event.modifierFlags.contains(.command) {
             return (.fallthrough, .fallthrough)
@@ -42,7 +43,7 @@ enum InputState {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
             case .suggest:
-                if Config.EnableOpenAiApiKey().value {
+                if enableSuggestion {
                     return (.requestSuggestion, .transition(.suggestion))
                 } else {
                     return (.fallthrough, .fallthrough)

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -42,7 +42,11 @@ enum InputState {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
             case .suggest:
-                return (.requestSuggestion, .transition(.suggestion))
+                if Config.EnableOpenAiApiKey().value{
+                    return (.requestSuggestion, .transition(.suggestion))
+                }else{
+                    return (.fallthrough, .fallthrough)
+                }
             case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment, .tab:
                 return (.fallthrough, .fallthrough)
             }

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -41,8 +41,8 @@ enum InputState {
                 } else {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
-            case .suggest:
-                if Config.EnableOpenAiApiKey().value {
+            case .suggest(let enableSuggest):
+                if  enableSuggest {
                     return (.requestSuggestion, .transition(.suggestion))
                 } else {
                     return (.fallthrough, .fallthrough)
@@ -225,9 +225,13 @@ enum InputState {
                 } else {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
-            case .suggest:
-                // 再度リクエスト
-                return (.requestSuggestion, .transition(.none))
+            case .suggest(let enableSuggest):
+                if enableSuggest {
+                    // 再度リクエスト
+                    return (.requestSuggestion, .transition(.none))
+                } else {
+                    return (.fallthrough, .fallthrough)
+                }
             case .tab:
                 return (.submitSuggestion, .transition(.none))
             case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment:

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -41,8 +41,8 @@ enum InputState {
                 } else {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
-            case .suggest(let enableSuggest):
-                if  enableSuggest {
+            case .suggest:
+                if Config.EnableOpenAiApiKey().value {
                     return (.requestSuggestion, .transition(.suggestion))
                 } else {
                     return (.fallthrough, .fallthrough)
@@ -225,13 +225,9 @@ enum InputState {
                 } else {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
-            case .suggest(let enableSuggest):
-                if enableSuggest {
-                    // 再度リクエスト
-                    return (.requestSuggestion, .transition(.none))
-                } else {
-                    return (.fallthrough, .fallthrough)
-                }
+            case .suggest:
+                // 再度リクエスト
+                return (.requestSuggestion, .transition(.none))
             case .tab:
                 return (.submitSuggestion, .transition(.none))
             case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment:

--- a/azooKeyMac/InputController/InputState.swift
+++ b/azooKeyMac/InputController/InputState.swift
@@ -42,9 +42,9 @@ enum InputState {
                     return (.insertWithoutMarkedText("　"), .transition(.none))
                 }
             case .suggest:
-                if Config.EnableOpenAiApiKey().value{
+                if Config.EnableOpenAiApiKey().value {
                     return (.requestSuggestion, .transition(.suggestion))
-                }else{
+                } else {
                     return (.fallthrough, .fallthrough)
                 }
             case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment, .tab:

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -282,14 +282,9 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         case .stopComposition:
             self.segmentsManager.stopComposition()
         case .requestSuggestion:
-            // configの有効化をチェック
-            if Config.EnableOpenAiApiKey().value && Config.OpenAiApiKey().value.isEmpty == false {
-                self.requestSuggestion()
-            }
+            self.requestSuggestion()
         case .submitSuggestion:
-            if Config.EnableOpenAiApiKey().value && Config.OpenAiApiKey().value.isEmpty == false {
-                self.submitSelectedSuggestion()
-            }
+            self.submitSelectedSuggestion()
         // MARK: 特殊ケース
         case .consume:
             return true

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -164,7 +164,8 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
             event,
             userAction: userAction,
             liveConversionEnabled: Config.LiveConversion().value,
-            enableDebugWindow: Config.DebugWindow().value
+            enableDebugWindow: Config.DebugWindow().value,
+            enableSuggestion: Config.EnableOpenAiApiKey().value
         )
         return handleClientAction(clientAction, clientActionCallback: clientActionCallback, client: client)
     }


### PR DESCRIPTION
- Suggestのショートカットを既存のキーバインドと競合しないctrl + sに変更
- 補完機能がオフのときにショートカットの入力をfallthroughする
