### PR TITLE
Fix: デバッグウィンドウの表示設定をデフォルトでオフにする

### DIFF
--- a/azooKeyMac/Configs/BoolConfigItem.swift
+++ b/azooKeyMac/Configs/BoolConfigItem.swift
@@ -29,7 +29,7 @@ extension BoolConfigItem {
 extension Config {
     /// デバッグウィンドウにd/Dで遷移する設定
     struct DebugWindow: BoolConfigItem {
-        static let `default` = true
+        static let `default` = false
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.debug.enableDebugWindow"
     }
     /// ライブ変換を有効化する設定


### PR DESCRIPTION
Fixes #94

Update the default value of the DebugWindow setting to false.

* Change the `default` value of the `DebugWindow` struct in `azooKeyMac/Configs/BoolConfigItem.swift` from `true` to `false`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ensan-hcl/azooKey-Desktop/pull/95?shareId=84afc338-f5f9-4945-b420-07bd485024ef).