### PR TITLE
fix: マウスクリックで変換を確定した際に文字が二重に入力される問題を修正

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -100,20 +100,25 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
 
     @MainActor
     override func deactivateServer(_ sender: Any!) {
-        // 未確定テキストが残っている場合は確定させる
-        if !self.segmentsManager.isEmpty {
-            let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
-            if let client = sender as? IMKTextInput {
-                client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
-            }
-            self.inputState = .none // 状態をリセット
-            self.refreshMarkedText() // クライアントのmarkedTextを確実にクリア
-        }
         self.segmentsManager.deactivate()
         self.candidatesWindow.orderOut(nil)
         self.replaceSuggestionWindow.orderOut(nil)
         self.candidatesViewController.updateCandidates([], selectionIndex: nil, cursorLocation: .zero)
         super.deactivateServer(sender)
+    }
+
+    @MainActor
+    override func commitComposition(_ sender: Any!) {
+        if self.segmentsManager.isEmpty {
+            return
+        }
+        let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
+        if let client = sender as? IMKTextInput {
+            client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        self.inputState = .none
+        self.refreshMarkedText()
+        self.refreshCandidateWindow()
     }
 
     @MainActor


### PR DESCRIPTION
マウスクリックで変換を確定した際に文字が二重に入力される問題を修正しました。

- No-Op だった `override func commitComposition()` を実装することで、azooKeyのUserActionを経由しない変換確定を、azooKey側で処理できるようにした。
- PR #156 では、`override func deactivateServer()` に処理を追加することで #138 を解決したが、InputMethod 切替でも `deactivateServer()` の前に `commitComposition()` が呼ばれることが分かったので、 `commitComposition()` 内に処理を集約した。