### PR TITLE
fix: Xcode 26.1でのビルドエラーを修正

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -3,29 +3,6 @@
 
 import PackageDescription
 
-#if canImport(FoundationModels)
-let isXcodeVersion26 = true
-#else
-let isXcodeVersion26 = false
-#endif
-
-let xcode26AdditionalTargets: [Target] = [
-    .binaryTarget(
-        // Note: Xcode 26以降、AzooKeyKanaKanjiConverter側のXCFrameworkのbinaryTargetをXcodeが解決してくれなくなった。
-        // そこで、binaryTargetを再度AzooKeyCore側でも要求することで、結果的に認識されるようになる。
-        // さらに`AzooKeyUtils`でも`llama`を要求しないとビルドは通らない。
-        // ただし、Xcode 26より前の場合は逆にこの対応を入れると動作しないので、Xcodeバージョンを確認する必要がある
-        name: "llama",
-        url: "https://github.com/azooKey/llama.cpp/releases/download/b4846/signed-llama.xcframework.zip",
-        // this can be computed `swift package compute-checksum llama-b4844-xcframework.zip`
-        checksum: "db3b13169df8870375f212e6ac21194225f1c85f7911d595ab64c8c790068e0a"
-    )
-]
-
-let xcode26AdditionalTargetDependency: [Target.Dependency] = [
-    "llama"
-]
-
 let package = Package(
     name: "Core",
     platforms: [.macOS(.v13)],
@@ -53,7 +30,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftUtils", package: "AzooKeyKanaKanjiConverter"),
                 .product(name: "KanaKanjiConverterModuleWithDefaultDictionary", package: "AzooKeyKanaKanjiConverter")
-            ] + (isXcodeVersion26 ? xcode26AdditionalTargetDependency : []),
+            ],
             swiftSettings: [.interoperabilityMode(.Cxx)],
             plugins: [
                 .plugin(name: "GitInfoPlugin")
@@ -64,5 +41,5 @@ let package = Package(
             dependencies: ["Core"],
             swiftSettings: [.interoperabilityMode(.Cxx)]
         )
-    ] + (isXcodeVersion26 ? xcode26AdditionalTargets : [])
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ GitHub Sponsorsをご利用ください。
 
 コントリビュート歓迎です！！
 
-### 想定環境
+### 推奨環境
 * macOS 15+
-* Xcode 16+
+* Xcode 26.1+
 * Git LFS導入済み
 * SwiftLint導入済み
 
@@ -94,6 +94,7 @@ git submodule update --init
   * azooKeyMac -> Signing & Capabilities から、 Team を Personal Team に変更する
   * リポジトリ内に存在する全てのバンドルID文字列を、適当な文字列に置換 (ex: `dev.ensan.inputmethod.azooKeyMac` -> `dev.yourname.inputmethod.azooKeyMac`)
 * 「Packages are not supported when using legacy build locations, but the current project has them enabled.」と表示される場合は[https://qiita.com/glassmonkey/items/3e8203900b516878ff2c](https://qiita.com/glassmonkey/items/3e8203900b516878ff2c)を参考に、Xcodeの設定をご確認ください
+* Xcode 26.0ではビルドできない可能性があります。Xcode 16系または26.1以降をご利用ください。
 
 変換精度がリリース版に比べて悪いと感じた場合、以下をご確認ください。
 * Git LFSが導入されていない環境では、重みファイルがローカル環境に落とせていない場合があります。`azooKey-Desktop/azooKeyMac/Resources/zenz-v3-small-gguf/ggml-model-Q5_K_M.gguf`が70MB程度のファイルとなっているかを確認してください


### PR DESCRIPTION
#205 で導入した対応だったが、おそらくSwift側の修正によってXcode 26.1では必要なくなった。そこでXcode 26.1を前提に不要なワークアラウンドを取り除いた。