### PR TITLE
fix: F9/F10変換時に誤った記号に変換される問題を修正

### DIFF
--- a/Core/Sources/Core/KeyMap/KeyMap+hankaku2zenkaku.swift
+++ b/Core/Sources/Core/KeyMap/KeyMap+hankaku2zenkaku.swift
@@ -41,7 +41,7 @@ extension KeyMap {
         "]": "」",
         ",": "、",
         ".": "。",
-        "/": "／"
+        "/": "・"
     ]
 
     public static func h2zMap(_ text: Character) -> Character? {

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -210,10 +210,10 @@ extension UserAction {
                     .input(keyMap("?"))
                 } else if event.modifierFlags.contains(.option) {
                     // Option入力でSlashを入力する
-                    .input(keyMap("/"))
+                    .input(keyMap("／"))
                 } else {
-                    // そうでない場合は「・」を入力する
-                    .input(keyMap("・"))
+                    // そうでない場合は「・」を入力する（"/"がkeyMapで"・"に変換される）
+                    .input(keyMap("/"))
                 }
             case .english:
                 if let text = event.characters, isPrintable(text) {


### PR DESCRIPTION
#219 において、「/」キーで「・」を入力後、F9/F10で英数変換した際に、
期待される「／」「/」ではなく「・」「･」が出力される問題を修正しました。
