### PR TITLE
Unicode入力中に「マウスクリックでタゲを外した後」に文字入力を再開するとU+xxxxが重複する問題を解決

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -103,6 +103,12 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
 
     @MainActor
     override func commitComposition(_ sender: Any!) {
+        // Unicode入力モードの場合は状態だけリセットして終了
+        // マウスクリック等でOSがMarkedTextを確定した場合、IME側からは消せないため
+        if case .unicodeInput = self.inputState {
+            self.inputState = .none
+            return
+        }
         if self.segmentsManager.isEmpty {
             return
         }


### PR DESCRIPTION
【bug: Unicode 入力中にマウスクリックでタゲを外した後に文字入力を再開するとU+xxxxが重複する #237】
(https://github.com/azooKey/azooKey-Desktop/issues/237)

Unicode入力モード中にマウスクリック等で `commitComposition` が呼ばれた際、`inputState` が `.unicodeInput` のまま残る問題を修正しました。

・変更内容
`commitComposition` でUnicode入力モードの場合は `inputState` を `.none` にリセットして早期リターンするようにしました。

・既知の制限
マウスクリック時にOSがMarkedTextを先に確定してしまう(?)ため、「U+」がテキストとして残る問題自体は解決できていません。