### PR TITLE
feat: ConfigWindow のデザイン刷新

### DIFF
--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -321,7 +321,8 @@ struct ConfigWindow: View {
                         switch self.systemUserDictionaryUpdateMessage {
                         case .none:
                             if let updated = self.systemUserDictionary.value.lastUpdate {
-                                Text("最終更新: \(updated.formatted()) / \(self.systemUserDictionary.value.items.count)件のアイテム")
+                                let date = updated.formatted(date: .omitted, time: .omitted)
+                                Text("最終更新: \(date) / \(self.systemUserDictionary.value.items.count)件のアイテム")
                             } else {
                                 Text("未設定")
                             }
@@ -357,6 +358,17 @@ struct ConfigWindow: View {
 
             Section {
                 Toggle("ライブ変換を有効化", isOn: $liveConversion)
+                HStack {
+                    TextField("変換プロフィール", text: $zenzaiProfile, prompt: Text("例：田中太郎/高校生"))
+                    helpButton(
+                        helpContent: """
+                    Zenzaiはあなたのプロフィールを考慮した変換を行うことができます。
+                    名前や仕事、趣味などを入力すると、それに合わせた変換が自動で推薦されます。
+                    （実験的な機能のため、精度が不十分な場合があります）
+                    """,
+                        isPresented: $zenzaiProfileHelpPopover
+                    )
+                }
             } header: {
                 Label("変換設定", systemImage: "brain")
             }
@@ -400,6 +412,7 @@ struct ConfigWindow: View {
                             Text("エラー: \(message)")
                                 .foregroundColor(.red)
                         }
+                        Spacer()
                         Button("リセット") {
                             showingLearningResetConfirmation = true
                         }
@@ -430,8 +443,12 @@ struct ConfigWindow: View {
                     Text("カスタム").tag(Config.InputStyle.Value.custom)
                 }
                 if inputStyle.value == .custom {
-                    Button("カスタム入力テーブルを編集") {
-                        showingRomajiTableEditor = true
+                    LabeledContent {
+                        Button("編集") {
+                            showingRomajiTableEditor = true
+                        }
+                    } label: {
+                        Text("カスタム入力テーブル")
                     }
                 }
             } header: {


### PR DESCRIPTION
## 概要

ConfigWindow を現代的なタブインターフェースにリデザインし、設定項目を整理しました。

## 主な変更内容

### UI/UX の刷新

1. **タブインターフェースの導入**
   - 設定を「基本」「カスタマイズ」「詳細設定」の3つのタブに整理
   - アイコン付きの見やすいタブデザイン
   - 角丸デザイン（cornerRadius: 6/10）で統一感のある見た目

2. **モダンなタブデザイン**
   - 選択タブ：アクセントカラーのアイコン + controlBackgroundColor の背景
   - 未選択タブ：secondaryLabelColor でシンプルに
   - タブバー全体を角丸背景で囲み、macOS ネイティブな質感

3. **レイアウトの改善**
   - ボタンを右端に配置（ユーザ辞書編集、履歴学習リセット）
   - 情報表示を左側に配置
   - より標準的な macOS 設定画面のレイアウトに準拠

### タブ構成

- **基本**: いい感じ変換、ユーザ辞書、変換プロフィール
- **カスタマイズ**: 入力方式、入力オプション、学習設定
- **詳細設定**: Zenzai 詳細設定、キーボード配列、開発者向け設定、アプリ情報

### 技術的改善

- @ConfigState から直接 UserDefaults/Keychain アクセスに変更してパフォーマンス改善
- SwiftUI TabView の代わりにカスタム実装でレインボーカーソル問題を解決
- 非同期バックグラウンドロードで初期表示を高速化
- キャッシング戦略により不要な再レンダリングを削減

## スクリーンショット

<img width="1242" height="1124" alt="CleanShot 2025-12-31 at 00 13 30@2x" src="https://github.com/user-attachments/assets/1aa534da-9479-4f24-b682-6a58f9e391c4" />
<img width="1256" height="1144" alt="CleanShot 2025-12-31 at 00 13 25@2x" src="https://github.com/user-attachments/assets/74128a8a-94ed-4d39-a4af-639dd1aa59bd" />
<img width="1320" height="1132" alt="CleanShot 2025-12-31 at 00 13 20@2x" src="https://github.com/user-attachments/assets/477d03b2-3dc0-421f-b766-1d58748b4191" />


## テスト項目

- [x] 全てのタブが正しく表示される
- [x] タブ切り替えがスムーズ（レインボーカーソルなし）
- [x] 全ての設定値が正しく読み込まれ、保存される
- [x] UIが macOS ネイティブな見た目になっている
- [x] SwiftLint チェックが通過する
