### PR TITLE
fix: いい感じ変換ウィンドウでモデル名が候補と重なる問題を修正

### DIFF
--- a/azooKeyMac/InputController/CandidateWindow/SuggestCandidatesViewController.swift
+++ b/azooKeyMac/InputController/CandidateWindow/SuggestCandidatesViewController.swift
@@ -8,45 +8,6 @@ import KanaKanjiConverterModule
 
 class ReplaceSuggestionsViewController: BaseCandidateViewController {
     weak var delegate: (any ReplaceSuggestionsViewControllerDelegate)?
-    private var modelLabel: NSTextField?
-
-    private var modelDisplayName: String {
-        let backend = Config.AIBackendPreference().value
-        switch backend {
-        case .off:
-            return "Off"
-        case .foundationModels:
-            return "Foundation Models"
-        case .openAI:
-            let modelName = Config.OpenAiModelName().value
-            return modelName.isEmpty ? "OpenAI API" : modelName
-        }
-    }
-
-    override func loadView() {
-        super.loadView()
-
-        // Add model name label at the bottom of the window
-        let label = NSTextField(labelWithString: modelDisplayName)
-        label.font = NSFont.systemFont(ofSize: 8)
-        label.textColor = .secondaryLabelColor
-        label.alignment = .center
-        label.translatesAutoresizingMaskIntoConstraints = false
-        self.modelLabel = label
-
-        self.view.addSubview(label)
-
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            label.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -2)
-        ])
-    }
-
-    override func viewWillAppear() {
-        super.viewWillAppear()
-        // Update model label when view appears
-        modelLabel?.stringValue = modelDisplayName
-    }
 
     override internal func updateSelectionCallback(_ row: Int) {
         delegate?.replaceSuggestionSelectionChanged(row)


### PR DESCRIPTION
## 概要

いい感じ変換の候補ウィンドウ（`ReplaceSuggestionsViewController`）で、下部に表示していたモデル名ラベルが候補テキストと重なっていた問題を修正しました。

## 問題

- モデル名ラベルを`containerView`の`bottomAnchor`に配置していた
- `scrollView`も同じ`bottomAnchor`まで伸びていたため、最下部の候補とモデル名が重なっていた
- レイアウト制約の競合により、視認性が低下していた

## 対応内容

`ReplaceSuggestionsViewController`からモデル名表示機能を削除しました：
- `modelLabel`プロパティの削除
- `modelDisplayName`計算プロパティの削除
- `loadView()`および`viewWillAppear()`のオーバーライドを削除

## 影響範囲

- いい感じ変換の候補ウィンドウからモデル名表示が削除される
- プロンプト入力画面には引き続きモデル名が表示される
- 既存の機能や設定には影響なし

## 関連Issue

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)