### PR TITLE
feat: Increase Zenzai inference default limit to 5

### DIFF
--- a/Core/Sources/Core/Configs/IntConfigItem.swift
+++ b/Core/Sources/Core/Configs/IntConfigItem.swift
@@ -22,7 +22,7 @@ extension IntConfigItem {
 extension Config {
     public struct ZenzaiInferenceLimit: IntConfigItem {
         public init() {}
-        static let `default` = 1
+        static let `default` = 5
         public static let key = "dev.ensan.inputmethod.azooKeyMac.preference.zenzaiInferenceLimit"
     }
 }


### PR DESCRIPTION
### Motivation
- The `ZenzaiInferenceLimit` default was previously `1` and the change raises the initial inference capacity. 
- The intent is to provide a higher out-of-the-box inference limit so users do not need to adjust this setting immediately.

### Description
- Updated `Config.ZenzaiInferenceLimit` default from `1` to `5` in `Core/Sources/Core/Configs/IntConfigItem.swift`.
- This change affects reads of `Config.ZenzaiInferenceLimit().value`, which are used in modules such as `SegmentsManager.swift` and `ConfigWindow.swift`.
- No API surface or runtime logic beyond the default configuration value was modified.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c547c72488330a13b6e1629a7fb2e)