### PR TITLE
fix: 複数のgit tagがある場合、最新のものを利用するよう変更

### DIFF
--- a/Core/Sources/git-info-generator/main.swift
+++ b/Core/Sources/git-info-generator/main.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-var tag = try? shell("git tag --points-at HEAD")
+var tag = try? shell("git for-each-ref refs/tags --points-at HEAD --sort=-creatordate --format='%(refname:short)' | head -n 1")
 var commit = try? shell("git rev-parse HEAD")
 if tag?.isEmpty == true {
     tag = nil


### PR DESCRIPTION
以下のように、git tagは複数並ぶことがあるが、従来実装ではこれが解決されていなかった。この実装では、明示的に最初の一行を取り出すようにしたので、この問題は生じない。
```
v0.1.3
v0.1.3-beta.1
```