### PR TITLE
refactor: ModifierFlagをenumからOptionSetに変更

### DIFF
--- a/Core/Sources/Core/InputUtils/KeyEventCore.swift
+++ b/Core/Sources/Core/InputUtils/KeyEventCore.swift
@@ -1,18 +1,24 @@
 public struct KeyEventCore: Sendable, Equatable {
-    public enum ModifierFlag: Sendable, Equatable, Hashable {
-        case option
-        case control
-        case command
-        case shift
+    public struct ModifierFlag: OptionSet, Sendable, Hashable {
+        public let rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        public static let shift   = ModifierFlag(rawValue: 1 << 0)
+        public static let control = ModifierFlag(rawValue: 1 << 1)
+        public static let option  = ModifierFlag(rawValue: 1 << 2)
+        public static let command = ModifierFlag(rawValue: 1 << 3)
     }
 
-    public init(modifierFlags: [ModifierFlag], characters: String?, charactersIgnoringModifiers: String?, keyCode: UInt16) {
+    public init(modifierFlags: ModifierFlag, characters: String?, charactersIgnoringModifiers: String?, keyCode: UInt16) {
         self.modifierFlags = modifierFlags
         self.characters = characters
         self.charactersIgnoringModifiers = charactersIgnoringModifiers
         self.keyCode = keyCode
     }
-    var modifierFlags: [ModifierFlag]
+    var modifierFlags: ModifierFlag
     var characters: String?
     var charactersIgnoringModifiers: String?
     var keyCode: UInt16

--- a/azooKeyMac/InputController/NSEvent.swift
+++ b/azooKeyMac/InputController/NSEvent.swift
@@ -3,18 +3,18 @@ import Core
 
 extension NSEvent {
     var keyEventCore: KeyEventCore {
-        var modifierFlags: [KeyEventCore.ModifierFlag] = []
+        var modifierFlags: KeyEventCore.ModifierFlag = []
         if self.modifierFlags.contains(.shift) {
-            modifierFlags.append(.shift)
+            modifierFlags.insert(.shift)
         }
         if self.modifierFlags.contains(.control) {
-            modifierFlags.append(.control)
+            modifierFlags.insert(.control)
         }
         if self.modifierFlags.contains(.command) {
-            modifierFlags.append(.command)
+            modifierFlags.insert(.command)
         }
         if self.modifierFlags.contains(.option) {
-            modifierFlags.append(.option)
+            modifierFlags.insert(.option)
         }
         return KeyEventCore(
             modifierFlags: modifierFlags,


### PR DESCRIPTION
このPRは、Unicode入力のショートカット (Shift+Control+U) が動作しなくなっていた問題を修正します。#264 により、UserAction の modifier 取得が `event.modifierFlags` から `eventCore.modifierFlags` に変更され、修飾キー配列の順序を考慮した判定が必要となりました。