### PR TITLE
feat: Support Dvorak-QWERTY ⌘ keyboard layout

### DIFF
--- a/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
+++ b/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
@@ -179,6 +179,7 @@ extension Config {
             case qwerty
             case colemak
             case dvorak
+            case dvorakQwertyCommand
 
             public var layoutIdentifier: String {
                 switch self {
@@ -188,6 +189,8 @@ extension Config {
                     return "com.apple.keylayout.Colemak"
                 case .dvorak:
                     return "com.apple.keylayout.Dvorak"
+                case .dvorakQwertyCommand:
+                    return "com.apple.keylayout.DVORAK-QWERTYCMD"
                 }
             }
         }

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -460,6 +460,7 @@ struct ConfigWindow: View {
                     Text("QWERTY").tag(Config.KeyboardLayout.Value.qwerty)
                     Text("Colemak").tag(Config.KeyboardLayout.Value.colemak)
                     Text("Dvorak").tag(Config.KeyboardLayout.Value.dvorak)
+                    Text("Dvorak - QWERTY ⌘").tag(Config.KeyboardLayout.Value.dvorakQwertyCommand)
                 }
             } header: {
                 Label("キーボード配列", systemImage: "keyboard.badge.ellipsis")


### PR DESCRIPTION
## Summary
Adds support for macOS's built-in "Dvorak - QWERTY ⌘" layout (`com.apple.keylayout.DVORAK-QWERTYCMD`), which uses QWERTY mapping when Command key is pressed.

## Motivation
Standard Dvorak layout has poor accessibility for common shortcut keys (C, V, X, Z). The "Dvorak - QWERTY ⌘" layout solves this by temporarily switching to QWERTY when Command is held, making shortcuts more ergonomic for Dvorak users.

## Changes

  * Added "Dvorak - QWERTY ⌘" and `com.apple.keylayout.DVORAK-QWERTYCMD` to `KeyboardLayout` and config window

## Additional context

Related to #268 