### PR TITLE
feat: Google IMEと同等の日付変換フォーマットを追加

### DIFF
--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -371,8 +371,7 @@ public final class SegmentsManager {
                     .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "1", deltaUnit: 60 * 60 * 24).export(), ruby: "アシタ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
                     .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "2", deltaUnit: 60 * 60 * 24).export(), ruby: "アサッテ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value)
                 ]
-            }
-            + [
+            } + [
                 // 月
                 .init(word: DateTemplateLiteral(format: "MM月", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コンゲツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
                 // 年


### PR DESCRIPTION
## Summary
- 「きょう」「きのう」「あした」などの日付変換で、Google IMEと同等のフォーマットを追加
- ハイフン区切り（2026-01-12）
- ゼロ埋めなし漢字表記（2026年1月12日）
- 和暦表記（令和8年1月12日）
- 曜日のみ（月曜日）

## 変更内容
- 日付変換フォーマットの追加（522f762）
- フィードバック対応: ゼロ埋めあり漢字表記（2026年01月12日）を廃止し、ゼロ埋めなし（2026年1月12日）のみを採用（795425c）
- 実装のリファクタリング: 3つのflatMapブロックを1つに統合、CalendarTypeを配列として明示的に指定（f5e1709）
- 優先度（value）の値を連番に整理（cd1e3ee）
- コードフォーマットの調整（94ec11e）

## Test plan
- [ ] アプリをビルドして起動
- [ ] 「きょう」と入力し、新しいフォーマットが変換候補に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)