### PR TITLE
fix: prompt window focus restoration

### DIFF
--- a/azooKeyMac/Windows/PromptInput/PromptInputWindow.swift
+++ b/azooKeyMac/Windows/PromptInput/PromptInputWindow.swift
@@ -16,7 +16,6 @@ final class PromptInputWindow: NSWindow {
     private var applyCallback: ((String) -> Void)?
     private var isTextFieldCurrentlyFocused: Bool = false
     private var initialPrompt: String?
-    private var previousApp: NSRunningApplication?
 
     init() {
         super.init(
@@ -92,12 +91,6 @@ final class PromptInputWindow: NSWindow {
         self.applyCallback = onApply
         self.completion = completion
         self.initialPrompt = initialPrompt
-        let frontmostApp = NSWorkspace.shared.frontmostApplication
-        if let frontmostApp, frontmostApp.processIdentifier != NSRunningApplication.current.processIdentifier {
-            self.previousApp = frontmostApp
-        } else {
-            self.previousApp = nil
-        }
 
         // Reset the window display state
         resetWindowState()
@@ -168,18 +161,6 @@ final class PromptInputWindow: NSWindow {
     }
 
     override func close() {
-        // Call completion handler to reset flags before closing
-        if let completion = self.completion {
-            completion(nil)
-        }
-
-        // Restore focus to the previous application
-        if let previousApp = self.previousApp {
-            DispatchQueue.main.async {
-                previousApp.activate(options: [])
-            }
-        }
-
         super.close()
         self.completion = nil
         self.previewCallback = nil


### PR DESCRIPTION
## 概要

PromptInputWindow のクローズ時に行っていたフォーカス復帰処理を削除し、frontmost appの復帰責務を呼び出し元に一本化しました。

## 背景

PromptInputWindow 自身と呼び出し元の両方でフォーカス復帰を行っており、アプリ切り替え後に azooKey が入力先を正しく追従できなくなる原因になっている可能性がありました。具体的には、アプリの切り替え時に、frontmost ウインドウに入力できない問題が発生していました。

## 変更内容

- PromptInputWindow から previousApp の保持を削除
- showPromptInput(...) 内の frontmostApplication 保存処理を削除
- close() から以下を削除
  - completion(nil) の呼び出し
  - previousApp.activate(options: []) によるフォーカス復帰

## 期待する効果

- アプリ切り替え後に azooKey で入力できなくなる事象の改善
- frontmost window 認識ずれの抑制
- フォーカス制御の単純化