### PR TITLE
fix: 未定義のCtrl+キーの組み合わせをIMEで処理しないようにする

### DIFF
--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -156,6 +156,9 @@ public enum UserAction {
                 return .suggest
             case ("u", [.control, .shift]): // Shift + Control + u
                 return .startUnicodeInput
+            case (_, let modifierFlags) where modifierFlags.contains(.control):
+                // Controlが押されているが、上記のどのショートカットにも当てはまらない場合は、未知のアクションとして扱う
+                return .unknown
 
             case ("¥", [.shift, .option]), ("¥", [.shift]), ("\\", [.shift, .option]), ("\\", [.shift]):
                 return .input(keyMap("|"))


### PR DESCRIPTION
## 概要

azookey(日本語)を使用時に、Ctrl+`など、IMEで明示的に処理していないCtrl+キーの組み合わせが全角文字として入力されてしまう問題を修正しました。

## 背景

具体例として、VSCodeにはCtrl + \` (バッククォート) でターミナルの表示/非表示を切り替えできるショートカットがありますが、azooKey(日本語)を使用時に、ターミナルがトグルできずに`(バッククォート)が入力されてしまいます。(動画参照)
これは、macOS標準の日本語IME使用時には発生せず、他のアプリのショートカットでも問題となる可能性があります。

https://github.com/user-attachments/assets/9c5dec63-638a-48bc-8d7e-7ade798ba642

## 原因

`UserAction.getUserAction()` において、Ctrl+キーの組み合わせのうち明示的に処理していないもの(Ctrl+H, Ctrl+Pなど以外)が、`default` ケースに到達し `.input()` として処理されていました。                                                      
これによりアプリにショートカットが渡らなくなっていました。

## 変更内容
                                                                                                                      
- `UserAction.swift`の論理キー判定部分で、明示的に処理しているCtrl+キーの個別ケースの直後に、Controlを含む未定義の組み合わせを`.unknown` として返すケースを追加
                                                                                                                      
## Test plan                                                             
                                                                                                                      
- [x] `swift test --package-path Core` が全テストパス
- [x] `./install.sh` でビルド＆インストール後、VSCodeでCtrl+`によるターミナルトグルが動作することを確認(下記動画参照)
- [x] 既存のCtrl+キーのショートカット（Ctrl+H, Ctrl+J等）が引き続き動作することを確認

https://github.com/user-attachments/assets/db03014c-c782-44a7-9a0d-33fd27034bda

久しぶりにswiftを読み書きしたので、修正点等あれば遠慮なく指摘してください。よろしくお願いします。