### PR TITLE
fix: 英語composing状態でスペースキーを押した場合に半角空白を入力する

### DIFF
--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -140,7 +140,9 @@ public enum InputState: Sendable, Hashable {
             case .escape:
                 return (.stopComposition, .transition(.none))
             case .space:
-                if liveConversionEnabled {
+                if inputLanguage == .english {
+                    return (.appendToMarkedText(" "), .fallthrough)
+                } else if liveConversionEnabled {
                     return (.enterCandidateSelectionMode, .transition(.selecting))
                 } else {
                     return (.enterFirstCandidatePreviewMode, .transition(.previewing))

--- a/Core/Tests/CoreTests/InputUtilsTests/InputStateSpaceTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/InputStateSpaceTests.swift
@@ -1,0 +1,84 @@
+import Core
+import Foundation
+import KanaKanjiConverterModule
+import Testing
+
+private let spaceEvent = KeyEventCore(
+    modifierFlags: [],
+    characters: " ",
+    charactersIgnoringModifiers: " ",
+    keyCode: 49
+)
+
+@Suite("InputState space key behavior in composing state")
+struct InputStateSpaceTests {
+    @Test func spaceInEnglishComposingAppendsSpace() {
+        let (action, _) = InputState.composing.event(
+            eventCore: spaceEvent,
+            userAction: .space(prefersFullWidthWhenInput: false),
+            inputLanguage: .english,
+            liveConversionEnabled: false,
+            enableDebugWindow: false,
+            enableSuggestion: false
+        )
+        guard case .appendToMarkedText(let text) = action else {
+            Issue.record("Expected appendToMarkedText, got \(action)")
+            return
+        }
+        #expect(text == " ")
+    }
+
+    @Test func spaceInEnglishComposingAppendsSpaceEvenWithLiveConversion() {
+        let (action, _) = InputState.composing.event(
+            eventCore: spaceEvent,
+            userAction: .space(prefersFullWidthWhenInput: false),
+            inputLanguage: .english,
+            liveConversionEnabled: true,
+            enableDebugWindow: false,
+            enableSuggestion: false
+        )
+        guard case .appendToMarkedText(let text) = action else {
+            Issue.record("Expected appendToMarkedText, got \(action)")
+            return
+        }
+        #expect(text == " ")
+    }
+
+    @Test func spaceInJapaneseComposingWithLiveConversionEntersCandidateSelection() {
+        let (action, callback) = InputState.composing.event(
+            eventCore: spaceEvent,
+            userAction: .space(prefersFullWidthWhenInput: false),
+            inputLanguage: .japanese,
+            liveConversionEnabled: true,
+            enableDebugWindow: false,
+            enableSuggestion: false
+        )
+        guard case .enterCandidateSelectionMode = action else {
+            Issue.record("Expected enterCandidateSelectionMode, got \(action)")
+            return
+        }
+        guard case .transition(.selecting) = callback else {
+            Issue.record("Expected transition(.selecting), got \(callback)")
+            return
+        }
+    }
+
+    @Test func spaceInJapaneseComposingWithoutLiveConversionEntersPreview() {
+        let (action, callback) = InputState.composing.event(
+            eventCore: spaceEvent,
+            userAction: .space(prefersFullWidthWhenInput: false),
+            inputLanguage: .japanese,
+            liveConversionEnabled: false,
+            enableDebugWindow: false,
+            enableSuggestion: false
+        )
+        guard case .enterFirstCandidatePreviewMode = action else {
+            Issue.record("Expected enterFirstCandidatePreviewMode, got \(action)")
+            return
+        }
+        guard case .transition(.previewing) = callback else {
+            Issue.record("Expected transition(.previewing), got \(callback)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## 概要

closes #248

英語入力モードで文字を入力中（composing状態）にスペースを押すと、変換候補選択モードに遷移してしまっていた問題を修正。

macOS標準IMEと同様に、半角スペースをmarked textに追記するよう変更。

## 再現手順

1. 日本語モードで何か入力してmarked textを作る（例: `は`）
2. 英数キーを押して英語モードに切り替える（marked textは残ったまま）
3. スペースを押す

**修正前**: 変換候補ウィンドウが開く  
**修正後**: 半角スペースがmarked textに追記される

## 変更内容

- `InputState.composing` 状態でスペースを押したとき、`inputLanguage == .english` の場合は `appendToMarkedText(" ")` を返すよう分岐を追加
- テスト4ケース追加（英語/日本語 × liveConversionあり/なし）