### PR TITLE
docs: 開発版のビルド手順を実態に合わせて修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,31 +57,58 @@ GitHub Sponsorsをご利用ください。
 
 コントリビュート歓迎です！！
 
-### 推奨環境
+### 必要な環境
 * macOS 15+
 * Xcode 26.1+
-* Git LFS導入済み
-* SwiftLint導入済み
+* Git LFS（必須。Hugging Face上のsubmoduleがLFSを利用しているため、未導入だとモデル重みが取得できません）
+* SwiftLint
+
+```bash
+brew install git-lfs swiftlint
+git lfs install
+```
 
 ### 開発版のビルド・デバッグ
 
-まず、想定環境が整っていることを確認してください。 git-lfs のない状態では正しく clone できません。
+#### 1. クローン
 
-cloneする際には`--recursive`をつけてサブモジュールまでローカルに落としてください。
+submoduleにzenzのgguf重みと言語モデル（`.marisa`）が含まれるため、`--recursive`と Git LFS の有効化が必須です。
 
 ```bash
+git lfs install        # 未実行の場合のみ
 git clone https://github.com/azooKey/azooKey-Desktop --recursive
+cd azooKey-Desktop
 ```
 
-以下のスクリプトを用いて最新のコードをビルドしてください。`.pkg`によるインストールと同等になります。その後、上記の手順を行ってください。また、submoduleが更新されている場合は `git submodule update --init` を行ってください。
+既にcloneしていてsubmoduleやLFSが揃っていない場合は以下を実行してください。
 
 ```bash
-# submoduleを更新
 git submodule update --init
+git -C azooKeyMac/Resources/zenz-v3.1-small-gguf lfs pull
+git -C azooKeyMac/Resources/base_n5_lm lfs pull
+```
 
-# ビルド＆インストール
+重みファイルが正しく取得できているか、サイズで確認できます（数十MB以上あればLFSの実体、134B程度ならポインタのままです）。
+
+```bash
+ls -lh azooKeyMac/Resources/zenz-v3.1-small-gguf/ggml-model-Q5_K_M.gguf
+```
+
+#### 2. 署名の設定（初回のみ）
+
+`install.sh` はアーカイブビルドを行うため、Xcode上で署名設定が通っている必要があります。Apple Developer Programに加入していない場合は、Personal Teamでの署名に切り替えてください。
+
+* `azooKeyMac.xcodeproj` を Xcode で開く
+* azooKeyMac ターゲット → Signing & Capabilities で Team を自身の Personal Team に変更
+* リポジトリ内のバンドルID（`dev.ensan.inputmethod.azooKeyMac` など）を、自身の所有するプレフィックスに一括置換（例: `dev.yourname.inputmethod.azooKeyMac`）
+
+#### 3. ビルド＆インストール
+
+```bash
 ./install.sh
 ```
+
+`.pkg`によるインストールと同等の状態になります。その後、上記の「リリース版インストール」の手順（ログアウト→入力ソース追加）を行ってください。
 
 開発中はazooKeyのプロセスをkillすることで最新版を反映することが出来ます。また、必要に応じて入力ソースからazooKeyを削除して再度追加する、macOSからログアウトして再ログインするなど、リセットが必要になる場合があります。
 
@@ -89,15 +116,12 @@ git submodule update --init
 
 `install.sh`でビルドが成功しない場合、以下をご確認ください。
 
-* XcodeのGUI上で「Team ID」を変更する必要がある場合があります
-  * `azooKeyMac.xcodeproj` を Xcode で開く
-  * azooKeyMac -> Signing & Capabilities から、 Team を Personal Team に変更する
-  * リポジトリ内に存在する全てのバンドルID文字列を、適当な文字列に置換 (ex: `dev.ensan.inputmethod.azooKeyMac` -> `dev.yourname.inputmethod.azooKeyMac`)
+* 署名エラーで失敗する場合は、上記「署名の設定」が完了しているかを確認してください（Team変更とバンドルID置換の両方が必要です）
 * 「Packages are not supported when using legacy build locations, but the current project has them enabled.」と表示される場合は[https://qiita.com/glassmonkey/items/3e8203900b516878ff2c](https://qiita.com/glassmonkey/items/3e8203900b516878ff2c)を参考に、Xcodeの設定をご確認ください
 * Xcode 26.0ではビルドできない可能性があります。Xcode 16系または26.1以降をご利用ください。
 
 変換精度がリリース版に比べて悪いと感じた場合、以下をご確認ください。
-* Git LFSが導入されていない環境では、重みファイルがローカル環境に落とせていない場合があります。`azooKey-Desktop/azooKeyMac/Resources/zenz-v3-small-gguf/ggml-model-Q5_K_M.gguf`が70MB程度のファイルとなっているかを確認してください
+* Git LFSが導入されていない環境では、重みファイルがローカル環境に落とせていない場合があります。`azooKeyMac/Resources/zenz-v3.1-small-gguf/ggml-model-Q5_K_M.gguf` が数十MB以上あるかを確認し、ポインタのままであれば `git -C azooKeyMac/Resources/zenz-v3.1-small-gguf lfs pull` を実行してください
 
 ### pkgファイルの作成
 `pkgbuild.sh`によって配布用のdmgファイルを作成できます。`build/azooKeyMac.app` としてDeveloper IDで署名済みの.appを配置してください。


### PR DESCRIPTION
## Summary

- Git LFS を「推奨」から「必須」に昇格。`brew install git-lfs` と `git lfs install` を明示
- submodule (Hugging Face上のzenz gguf / base_n5_lm) が LFS を使っている旨と、`git -C <submodule> lfs pull` の手順を追加
- `install.sh` の前段に「署名の設定（初回のみ）」セクションを新設。Personal Team への変更とバンドルID置換を必須手順として明示（従来はトラブルシューティングに埋もれていた）
- トラブルシューティング内の重複を整理、stale path (`zenz-v3-small-gguf` → `zenz-v3.1-small-gguf`) を修正

## Motivation

READMEの手順通り `git clone --recursive` と `./install.sh` を実行しても、

- Git LFS 未導入だと submodule は LFS ポインタ（134B）のままで取得できず、モデル重みがローカルに落ちてこない
- Apple Developer Program 未加入の場合、`install.sh` が署名エラーで失敗する

という問題があり、初見のコントリビュータが詰まりやすかったため、実態に合わせて必須手順を整理しました。

## Test plan

- [ ] READMEのレンダリングがGitHub上で崩れていないこと
- [ ] 記載のコマンドがそのまま実行できること（`git lfs install` / `git lfs pull` / `ls -lh ...gguf`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)