### PR TITLE
feat: 英語入力への切り替えショートカットを追加 (#313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,31 +57,58 @@ GitHub Sponsorsをご利用ください。
 
 コントリビュート歓迎です！！
 
-### 推奨環境
+### 必要な環境
 * macOS 15+
 * Xcode 26.1+
-* Git LFS導入済み
-* SwiftLint導入済み
+* Git LFS（必須。Hugging Face上のsubmoduleがLFSを利用しているため、未導入だとモデル重みが取得できません）
+* SwiftLint
+
+```bash
+brew install git-lfs swiftlint
+git lfs install
+```
 
 ### 開発版のビルド・デバッグ
 
-まず、想定環境が整っていることを確認してください。 git-lfs のない状態では正しく clone できません。
+#### 1. クローン
 
-cloneする際には`--recursive`をつけてサブモジュールまでローカルに落としてください。
+submoduleにzenzのgguf重みと言語モデル（`.marisa`）が含まれるため、`--recursive`と Git LFS の有効化が必須です。
 
 ```bash
+git lfs install        # 未実行の場合のみ
 git clone https://github.com/azooKey/azooKey-Desktop --recursive
+cd azooKey-Desktop
 ```
 
-以下のスクリプトを用いて最新のコードをビルドしてください。`.pkg`によるインストールと同等になります。その後、上記の手順を行ってください。また、submoduleが更新されている場合は `git submodule update --init` を行ってください。
+既にcloneしていてsubmoduleやLFSが揃っていない場合は以下を実行してください。
 
 ```bash
-# submoduleを更新
 git submodule update --init
+git -C azooKeyMac/Resources/zenz-v3.1-small-gguf lfs pull
+git -C azooKeyMac/Resources/base_n5_lm lfs pull
+```
 
-# ビルド＆インストール
+重みファイルが正しく取得できているか、サイズで確認できます（数十MB以上あればLFSの実体、134B程度ならポインタのままです）。
+
+```bash
+ls -lh azooKeyMac/Resources/zenz-v3.1-small-gguf/ggml-model-Q5_K_M.gguf
+```
+
+#### 2. 署名の設定（初回のみ）
+
+`install.sh` はアーカイブビルドを行うため、Xcode上で署名設定が通っている必要があります。Apple Developer Programに加入していない場合は、Personal Teamでの署名に切り替えてください。
+
+* `azooKeyMac.xcodeproj` を Xcode で開く
+* azooKeyMac ターゲット → Signing & Capabilities で Team を自身の Personal Team に変更
+* リポジトリ内のバンドルID（`dev.ensan.inputmethod.azooKeyMac` など）を、自身の所有するプレフィックスに一括置換（例: `dev.yourname.inputmethod.azooKeyMac`）
+
+#### 3. ビルド＆インストール
+
+```bash
 ./install.sh
 ```
+
+`.pkg`によるインストールと同等の状態になります。その後、上記の「リリース版インストール」の手順（ログアウト→入力ソース追加）を行ってください。
 
 開発中はazooKeyのプロセスをkillすることで最新版を反映することが出来ます。また、必要に応じて入力ソースからazooKeyを削除して再度追加する、macOSからログアウトして再ログインするなど、リセットが必要になる場合があります。
 
@@ -89,15 +116,12 @@ git submodule update --init
 
 `install.sh`でビルドが成功しない場合、以下をご確認ください。
 
-* XcodeのGUI上で「Team ID」を変更する必要がある場合があります
-  * `azooKeyMac.xcodeproj` を Xcode で開く
-  * azooKeyMac -> Signing & Capabilities から、 Team を Personal Team に変更する
-  * リポジトリ内に存在する全てのバンドルID文字列を、適当な文字列に置換 (ex: `dev.ensan.inputmethod.azooKeyMac` -> `dev.yourname.inputmethod.azooKeyMac`)
+* 署名エラーで失敗する場合は、上記「署名の設定」が完了しているかを確認してください（Team変更とバンドルID置換の両方が必要です）
 * 「Packages are not supported when using legacy build locations, but the current project has them enabled.」と表示される場合は[https://qiita.com/glassmonkey/items/3e8203900b516878ff2c](https://qiita.com/glassmonkey/items/3e8203900b516878ff2c)を参考に、Xcodeの設定をご確認ください
 * Xcode 26.0ではビルドできない可能性があります。Xcode 16系または26.1以降をご利用ください。
 
 変換精度がリリース版に比べて悪いと感じた場合、以下をご確認ください。
-* Git LFSが導入されていない環境では、重みファイルがローカル環境に落とせていない場合があります。`azooKey-Desktop/azooKeyMac/Resources/zenz-v3-small-gguf/ggml-model-Q5_K_M.gguf`が70MB程度のファイルとなっているかを確認してください
+* Git LFSが導入されていない環境では、重みファイルがローカル環境に落とせていない場合があります。`azooKeyMac/Resources/zenz-v3.1-small-gguf/ggml-model-Q5_K_M.gguf` が数十MB以上あるかを確認し、ポインタのままであれば `git -C azooKeyMac/Resources/zenz-v3.1-small-gguf lfs pull` を実行してください
 
 ### pkgファイルの作成
 `pkgbuild.sh`によって配布用のdmgファイルを作成できます。`build/azooKeyMac.app` としてDeveloper IDで署名済みの.appを配置してください。

--- a/azooKeyMac/Info.plist
+++ b/azooKeyMac/Info.plist
@@ -15,10 +15,6 @@
 		<dict>
 			<key>com.apple.inputmethod.Roman</key>
 			<dict>
-				<key>tsInputModeKeyEquivalentModifiersKey</key>
-				<integer>4608</integer>
-				<key>tsInputModeKeyEquivalentKey</key>
-				<string>:</string>
 				<key>TISInputSourceID</key>
 				<string>dev.ensan.inputmethod.azooKeyMac.Roman</string>
 				<key>tsInputModePrimaryInScriptKey</key>

--- a/azooKeyMac/Info.plist
+++ b/azooKeyMac/Info.plist
@@ -15,6 +15,10 @@
 		<dict>
 			<key>com.apple.inputmethod.Roman</key>
 			<dict>
+				<key>tsInputModeKeyEquivalentModifiersKey</key>
+				<integer>4608</integer>
+				<key>tsInputModeKeyEquivalentKey</key>
+				<string>;</string>
 				<key>TISInputSourceID</key>
 				<string>dev.ensan.inputmethod.azooKeyMac.Roman</string>
 				<key>tsInputModePrimaryInScriptKey</key>

--- a/azooKeyMac/Info.plist
+++ b/azooKeyMac/Info.plist
@@ -21,6 +21,10 @@
 				<false/>
 				<key>tsInputModeScriptKey</key>
 				<string>smRoman</string>
+				<key>tsInputModeKeyEquivalentModifiersKey</key>
+				<integer>4608</integer>
+				<key>tsInputModeKeyEquivalentKey</key>
+				<string>;</string>
 				<key>tsInputModeJISKeyboardShortcutKey</key>
 				<integer>3</integer>
 				<key>tsInputModeDefaultStateKey</key>

--- a/azooKeyMac/Info.plist
+++ b/azooKeyMac/Info.plist
@@ -18,7 +18,7 @@
 				<key>tsInputModeKeyEquivalentModifiersKey</key>
 				<integer>4608</integer>
 				<key>tsInputModeKeyEquivalentKey</key>
-				<string>;</string>
+				<string>:</string>
 				<key>TISInputSourceID</key>
 				<string>dev.ensan.inputmethod.azooKeyMac.Roman</string>
 				<key>tsInputModePrimaryInScriptKey</key>

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -264,6 +264,24 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
             return false
         }
 
+        // 英語モード切り替えショートカット: Ctrl+Shift+;（keyCode 41）
+        // 日本語モードのCtrl+Shift+J（macOSのsmJapanese scriptに自動割り当て）と対になるショートカット
+        // smRoman scriptには自動割り当てがないため、自前でハンドルする必要がある
+        if event.keyCode == 41,
+           self.inputLanguage == .japanese,
+           event.modifierFlags.intersection([.control, .shift, .option, .command]) == [.control, .shift] {
+            if !self.segmentsManager.isEmpty {
+                let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
+                client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+                self.inputState = .none
+                self.refreshMarkedText()
+                self.refreshCandidateWindow()
+                self.refreshPredictionWindow()
+            }
+            self.switchInputLanguage(.english, client: client)
+            return true
+        }
+
         // カスタムプロンプトショートカットのチェック
         if let matchedPrompt = checkCustomPromptShortcut(event: event) {
             let aiBackendEnabled = Config.AIBackendPreference().value != .off

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -264,24 +264,6 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
             return false
         }
 
-        // 英語モード切り替えショートカット: Ctrl+Shift+;（keyCode 41）
-        // 日本語モードのCtrl+Shift+J（macOSのsmJapanese scriptに自動割り当て）と対になるショートカット
-        // smRoman scriptには自動割り当てがないため、自前でハンドルする必要がある
-        if event.keyCode == 41,
-           self.inputLanguage == .japanese,
-           event.modifierFlags.intersection([.control, .shift, .option, .command]) == [.control, .shift] {
-            if !self.segmentsManager.isEmpty {
-                let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
-                client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
-                self.inputState = .none
-                self.refreshMarkedText()
-                self.refreshCandidateWindow()
-                self.refreshPredictionWindow()
-            }
-            self.switchInputLanguage(.english, client: client)
-            return true
-        }
-
         // カスタムプロンプトショートカットのチェック
         if let matchedPrompt = checkCustomPromptShortcut(event: event) {
             let aiBackendEnabled = Config.AIBackendPreference().value != .off


### PR DESCRIPTION
## Summary

- azooKey日本語モード中に `Ctrl+Shift+;` で azooKey英語モードに切り替えられるようにした
- 日本語モードへの切り替え `Ctrl+Shift+J`（macOSがsmJapanese scriptに自動割り当て）と対になるショートカット
- キー割り当ては Google日本語入力に揃えた

Closes #313

## 実装の経緯

最初は `Info.plist` の `com.apple.inputmethod.Roman` に `tsInputModeKeyEquivalentModifiersKey` / `tsInputModeKeyEquivalentKey` を追加する方針で試したが、実機で動作しないことを確認した。原因はmacOSの仕様で、`smJapanese` scriptのプライマリIMEには `Ctrl+Shift+J` が自動割り当てされる一方、`smRoman` scriptには同様の自動割り当てがないため、Info.plistでショートカットを宣言してもOSに拾われない。

そこで `azooKeyMacInputController.handle(_:client:)` 内で直接ショートカットをキャッチする方針に変更した。Info.plistの実験的な変更は結局効果がなかったため最終的に差し戻している（コミット履歴には残っている）。

## 変更内容

- `azooKeyMac/InputController/azooKeyMacInputController.swift`: `handle()` の早い段階で `keyCode 41`（`;` キーの物理位置）+ Ctrl+Shift を検出し、`switchInputLanguage(.english)` を呼ぶ処理を追加。変換中のマークドテキストがある場合は確定してから切り替える

## 挙動

| 状態 | 挙動 |
|------|------|
| azooKey日本語モード / 何も入力していない | azooKey英語モードに切り替わる |
| azooKey日本語モード / 変換中 | マークドテキストを確定してから英語モードに切り替わる |
| azooKey英語モード | 何もしない（すでに英語なので無視） |
| OS標準英語モード等 azooKey非アクティブ時 | azooKeyは介入しない |

keyCodeベースで判定しているため、JIS/ANSIいずれのキーボードでも物理キー位置（USでの `;` 位置）で動作する。

## Test plan

- [x] azooKey日本語モードで `Ctrl+Shift+;` を押して英語モードに切り替わることをローカル実機で確認
- [x] 既存の `Ctrl+Shift+J` による日本語モード復帰動作に影響がないことを確認
- [ ] 変換中に `Ctrl+Shift+;` を押した場合、マークドテキストが確定されて英語モードに切り替わることを確認