### PR TITLE
fix: Chromium 系アプリの IME activateServer 時のハングを回避

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -39,15 +39,18 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     // ピン留めプロンプトのキャッシュ（パフォーマンス向上のため）
     private var pinnedPromptsCache: [PromptHistoryItem] = []
 
-    private static func makeCandidateWindow(contentViewController: NSViewController, inputClient: IMKTextInput?) -> NSWindow {
+    private static func makeCandidateWindow(contentViewController: NSViewController) -> NSWindow {
         let window = NSWindow(contentViewController: contentViewController)
         window.styleMask = [.borderless]
         window.level = .popUpMenu
 
-        var rect: NSRect = .zero
-        inputClient?.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
-        rect.size = candidateWindowInitialSize
-        window.setFrame(rect, display: true)
+        // Chromium 系アプリの deadlock 回避のため、初期化時に client への
+        // 問い合わせを行わない（Chromium issue 503787240）。
+        // ウィンドウは直後に orderOut されるため origin はユーザーから不可視であり、
+        // 最初の候補表示時に refreshCandidateWindow() で正しい位置に再配置される。
+        var frame = NSRect.zero
+        frame.size = candidateWindowInitialSize
+        window.setFrame(frame, display: true)
         window.setIsVisible(false)
         window.orderOut(nil)
         return window
@@ -121,8 +124,6 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
         self.liveConversionToggleMenuItem = NSMenuItem()
         self.transformSelectedTextMenuItem = NSMenuItem()
 
-        let textInputClient = inputClient as? IMKTextInput
-
         let candidatesViewController = CandidatesViewController()
         let predictionViewController = PredictionCandidatesViewController()
         let replaceSuggestionsViewController = ReplaceSuggestionsViewController()
@@ -131,18 +132,9 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
         self.predictionViewController = predictionViewController
         self.replaceSuggestionsViewController = replaceSuggestionsViewController
 
-        self.candidatesWindow = Self.makeCandidateWindow(
-            contentViewController: candidatesViewController,
-            inputClient: textInputClient
-        )
-        self.predictionWindow = Self.makeCandidateWindow(
-            contentViewController: predictionViewController,
-            inputClient: textInputClient
-        )
-        self.replaceSuggestionWindow = Self.makeCandidateWindow(
-            contentViewController: replaceSuggestionsViewController,
-            inputClient: textInputClient
-        )
+        self.candidatesWindow = Self.makeCandidateWindow(contentViewController: candidatesViewController)
+        self.predictionWindow = Self.makeCandidateWindow(contentViewController: predictionViewController)
+        self.replaceSuggestionWindow = Self.makeCandidateWindow(contentViewController: replaceSuggestionsViewController)
 
         // PromptInputWindowの初期化
         self.promptInputWindow = PromptInputWindow()
@@ -171,14 +163,18 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
 
         if let client = sender as? IMKTextInput {
             client.overrideKeyboard(withKeyboardNamed: Config.KeyboardLayout().value.layoutIdentifier)
-            var rect: NSRect = .zero
-            client.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
-            self.candidatesViewController.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: rect.origin)
-        } else {
-            self.candidatesViewController.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: .zero)
         }
-        self.refreshCandidateWindow()
-        self.refreshPredictionWindow()
+        // Chromium 系アプリで JS コンパイル中に activate された場合、
+        // client.attributes(forCharacterIndex:) の同期呼び出しが deadlock を
+        // 引き起こすため呼び出さない（Chromium issue 503787240）。
+        // refreshCandidateWindow / refreshPredictionWindow は composing/selecting 状態で
+        // client.attributes(...) を呼ぶ経路があるため、activate 中は使わずウィンドウを
+        // 明示的に閉じる。
+        self.candidatesViewController.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: .zero)
+        self.candidatesWindow.setIsVisible(false)
+        self.candidatesWindow.orderOut(nil)
+        self.candidatesViewController.hide()
+        self.hidePredictionWindow()
     }
 
     @MainActor

--- a/azooKeyMacTests/ChromiumDeadlockRegressionTests.swift
+++ b/azooKeyMacTests/ChromiumDeadlockRegressionTests.swift
@@ -1,0 +1,69 @@
+/// Chromium IME deadlock workaround に関する回帰テスト。
+///
+/// Chrome 等の Chromium 系ブラウザで大規模 JS バンドルのページを開いた直後、
+/// azooKey の activateServer 内で `client.attributes(forCharacterIndex:)` を呼ぶと
+/// deadlock が発生する問題（Chromium issue 503787240）を回避するための変更を保護する。
+///
+/// 安全性の根拠：
+/// - activateServer が渡す候補配列は空であるため、BaseCandidateViewController の
+///   `resizeWindowToFitContent` は `numberOfVisibleRows == 0` で早期 return し、
+///   cursorLocation は window 位置計算に使われない。
+/// - この事実が変わらない限り、activateServer 時の client 問い合わせを削除しても
+///   機能に影響がない。
+
+import XCTest
+import Core
+import KanaKanjiConverterModuleWithDefaultDictionary
+@testable import azooKeyMac
+
+final class ChromiumDeadlockRegressionTests: XCTestCase {
+    /// 空の候補配列で updateCandidatePresentations を呼んだ後、
+    /// numberOfVisibleRows が 0 であることを確認する。
+    ///
+    /// これにより、resizeWindowToFitContent の `numberOfVisibleRows == 0` での
+    /// 早期 return が継続的に機能することを保護する。
+    func test空配列でupdateCandidatePresentationsを呼ぶとnumberOfVisibleRowsが0になる() {
+        let vc = CandidatesViewController()
+        _ = vc.view // loadView を強制実行
+        vc.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: .zero)
+        XCTAssertEqual(
+            vc.numberOfVisibleRows,
+            0,
+            "空の候補配列では numberOfVisibleRows は 0 でなければならない"
+        )
+    }
+
+    /// 空の候補配列で updateCandidatePresentations を呼んだ後、
+    /// candidates プロパティが空であることを確認する。
+    func test空配列でupdateCandidatePresentationsを呼ぶとcandidatesが空になる() {
+        let vc = CandidatesViewController()
+        _ = vc.view
+        vc.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: .zero)
+        XCTAssertTrue(vc.candidates.isEmpty, "空の候補配列を渡した後、candidates は空でなければならない")
+    }
+
+    /// 0 より多い候補配列を渡した後に空配列で更新すると、
+    /// numberOfVisibleRows が 0 に戻ることを確認する。
+    func test候補が存在する状態から空配列に更新するとnumberOfVisibleRowsが0になる() {
+        let vc = CandidatesViewController()
+        _ = vc.view
+        let dummy = CandidatePresentation(
+            candidate: Candidate(
+                text: "テスト",
+                value: 0,
+                composingCount: .surfaceCount(3),
+                lastMid: 0,
+                data: []
+            )
+        )
+        vc.updateCandidatePresentations([dummy], selectionIndex: nil, cursorLocation: .zero)
+        XCTAssertEqual(vc.numberOfVisibleRows, 1, "候補が1件の状態を前提とする")
+
+        vc.updateCandidatePresentations([], selectionIndex: nil, cursorLocation: .zero)
+        XCTAssertEqual(
+            vc.numberOfVisibleRows,
+            0,
+            "空配列に更新した後は numberOfVisibleRows が 0 でなければならない"
+        )
+    }
+}

--- a/azooKeyMacTests/ChromiumDeadlockRegressionTests.swift
+++ b/azooKeyMacTests/ChromiumDeadlockRegressionTests.swift
@@ -16,6 +16,7 @@ import Core
 import KanaKanjiConverterModuleWithDefaultDictionary
 @testable import azooKeyMac
 
+@MainActor
 final class ChromiumDeadlockRegressionTests: XCTestCase {
     /// 空の候補配列で updateCandidatePresentations を呼んだ後、
     /// numberOfVisibleRows が 0 であることを確認する。


### PR DESCRIPTION
## 問題

Chrome 等 Chromium 系ブラウザで claude.ai / chatgpt.com のような大規模 JS バンドルのページを開いた直後、azooKey がフリーズする問題です。

**deadlock の発生フロー:**

1. ページが入力欄を autofocus → Chrome が `NSTextInputContext.activate()` を発行
2. macOS HIToolbox が azooKey の `activateServer(_:)` を**同期 XPC** で起動
3. `activateServer` 内で `client.attributes(forCharacterIndex:lineHeightRectangle:)` を呼び出す
4. Chrome の `NSTextInputClient` 実装が Renderer へ**同期 IPC** を発行し `pthread_cond_wait` で待機
5. Renderer は V8 の JS コンパイル中（6 秒以上）でキュー処理不可
6. azooKey は Chrome の応答待ちでブロック → **UI フリーズ**

根本原因は Chromium 側の実装にあります（ https://issues.chromium.org/issues/503787240 ）。Safari は WebKit の `firstRectForCharacterRange:` 実装が異なるため発生しません。

## 修正内容

`makeCandidateWindow` と `activateServer` から `client.attributes(forCharacterIndex:lineHeightRectangle:)` 呼び出しを削除します。以下の理由から機能的影響はありません。

- **`makeCandidateWindow`**: ウィンドウは直後に `orderOut` されるため、初期 origin はユーザーから不可視。最初の候補表示時に `refreshCandidateWindow()` で正しい位置に再配置されます。
- **`activateServer`**: 空の候補配列を渡しているため `BaseCandidateViewController.resizeWindowToFitContent` は `numberOfVisibleRows == 0` で早期 return し、`cursorLocation` は使われません。

また `activateServer` 内の `refreshCandidateWindow()` / `refreshPredictionWindow()` を明示的な hide/orderOut に置き換えます。これらのメソッドは composing/selecting 状態で `client.attributes(...)` を呼ぶ経路があるためです。

## 変更ファイル

- `azooKeyMac/InputController/azooKeyMacInputController.swift`
  - `makeCandidateWindow` から `inputClient` 引数と `attributes(forCharacterIndex:)` 呼び出しを削除
  - `activateServer` から `attributes(forCharacterIndex:)` 呼び出しを削除
  - `refreshCandidateWindow()` / `refreshPredictionWindow()` を明示的なウィンドウ hide に変更
- `azooKeyMacTests/ChromiumDeadlockRegressionTests.swift`（新規）
  - 安全性の根拠（空候補配列では cursorLocation が使われない）を保護する回帰テストを追加

## 動作確認

- Chrome で https://claude.ai および https://chatgpt.com を開いてもフリーズしなくなることを確認
- TextEdit / Safari / VSCode 等で日本語入力時に候補ウィンドウが正しいカーソル位置に表示されることを確認

Refs: https://issues.chromium.org/issues/503787240