### PR TITLE
ユーザー辞書の複数管理・インポート/エクスポート

### DIFF
--- a/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
+++ b/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
@@ -11,11 +11,16 @@ import enum KanaKanjiConverterModuleWithDefaultDictionary.LearningType
 
 protocol CustomCodableConfigItem: ConfigItem {
     static var `default`: Value { get }
+    static func shouldIncrementRevision(oldValue: Value?, newValue: Value) -> Bool
 }
 
 extension CustomCodableConfigItem {
     static var revisionKey: String {
         "\(Self.key).revision"
+    }
+
+    static func shouldIncrementRevision(oldValue: Value?, newValue: Value) -> Bool {
+        false
     }
 
     public var value: Value {
@@ -34,9 +39,14 @@ extension CustomCodableConfigItem {
         }
         nonmutating set {
             do {
+                let oldValue = UserDefaults.standard.data(forKey: Self.key).flatMap {
+                    try? JSONDecoder().decode(Value.self, from: $0)
+                }
                 let encoded = try JSONEncoder().encode(newValue)
                 UserDefaults.standard.set(encoded, forKey: Self.key)
-                UserDefaults.standard.set(UserDefaults.standard.integer(forKey: Self.revisionKey) + 1, forKey: Self.revisionKey)
+                if Self.shouldIncrementRevision(oldValue: oldValue, newValue: newValue) {
+                    UserDefaults.standard.set(UserDefaults.standard.integer(forKey: Self.revisionKey) + 1, forKey: Self.revisionKey)
+                }
             } catch {
                 print(#file, #line, error)
             }
@@ -158,6 +168,26 @@ extension Config {
             ])
         ])
         public static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.user_dictionary_temporal2"
+
+        static func shouldIncrementRevision(oldValue: Value?, newValue: Value) -> Bool {
+            Self.revisionSignature(oldValue ?? Self.default) != Self.revisionSignature(newValue)
+        }
+
+        private static func revisionSignature(_ value: Value) -> [String] {
+            value.dictionaries.flatMap { dictionary -> [String] in
+                guard dictionary.isEnabled else {
+                    return []
+                }
+                return ["enabled:\(dictionary.id.uuidString)"] + dictionary.items.map { item in
+                    [
+                        item.id.uuidString,
+                        item.word,
+                        item.reading,
+                        item.hint ?? ""
+                    ].joined(separator: "\u{1F}")
+                }
+            }
+        }
     }
 
     public struct SystemUserDictionary: CustomCodableConfigItem {
@@ -174,6 +204,22 @@ extension Config {
 
         public static let `default`: Value = .init(items: [])
         public static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.system_user_dictionary"
+
+        static func shouldIncrementRevision(oldValue: Value?, newValue: Value) -> Bool {
+            let oldItems = oldValue?.items ?? Self.default.items
+            return Self.revisionSignature(oldItems) != Self.revisionSignature(newValue.items)
+        }
+
+        private static func revisionSignature(_ items: [UserDictionaryEntry]) -> [String] {
+            items.map { item in
+                [
+                    item.id.uuidString,
+                    item.word,
+                    item.reading,
+                    item.hint ?? ""
+                ].joined(separator: "\u{1F}")
+            }
+        }
     }
 }
 

--- a/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
+++ b/Core/Sources/Core/Configs/CustomCodableConfigItem.swift
@@ -14,6 +14,10 @@ protocol CustomCodableConfigItem: ConfigItem {
 }
 
 extension CustomCodableConfigItem {
+    static var revisionKey: String {
+        "\(Self.key).revision"
+    }
+
     public var value: Value {
         get {
             guard let data = UserDefaults.standard.data(forKey: Self.key) else {
@@ -32,6 +36,7 @@ extension CustomCodableConfigItem {
             do {
                 let encoded = try JSONEncoder().encode(newValue)
                 UserDefaults.standard.set(encoded, forKey: Self.key)
+                UserDefaults.standard.set(UserDefaults.standard.integer(forKey: Self.revisionKey) + 1, forKey: Self.revisionKey)
             } catch {
                 print(#file, #line, error)
             }
@@ -67,8 +72,8 @@ extension Config {
 
 extension Config {
     public struct UserDictionaryEntry: Sendable, Codable, Identifiable {
-        public init(word: String, reading: String, hint: String? = nil) {
-            self.id = UUID()
+        public init(id: UUID = UUID(), word: String, reading: String, hint: String? = nil) {
+            self.id = id
             self.word = word
             self.reading = reading
             self.hint = hint
@@ -77,7 +82,7 @@ extension Config {
         public var id: UUID
         public var word: String
         public var reading: String
-        var hint: String?
+        public var hint: String?
 
         public var nonNullHint: String {
             get {
@@ -93,9 +98,52 @@ extension Config {
         }
     }
 
+    public struct UserDictionaryGroup: Sendable, Codable, Identifiable {
+        public init(id: UUID = UUID(), name: String, isEnabled: Bool = true, items: [UserDictionaryEntry] = []) {
+            self.id = id
+            self.name = name
+            self.isEnabled = isEnabled
+            self.items = items
+        }
+
+        public var id: UUID
+        public var name: String
+        public var isEnabled: Bool
+        public var items: [UserDictionaryEntry]
+    }
+
     public struct UserDictionary: CustomCodableConfigItem {
         public struct Value: Codable, Sendable {
-            public var items: [UserDictionaryEntry]
+            public var dictionaries: [UserDictionaryGroup]
+
+            public init(dictionaries: [UserDictionaryGroup]) {
+                self.dictionaries = dictionaries
+            }
+
+            public var items: [UserDictionaryEntry] {
+                dictionaries.flatMap(\.items)
+            }
+
+            public var enabledItems: [UserDictionaryEntry] {
+                dictionaries.filter(\.isEnabled).flatMap(\.items)
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                if let dictionaries = try container.decodeIfPresent([UserDictionaryGroup].self, forKey: .dictionaries) {
+                    self.dictionaries = dictionaries
+                } else {
+                    let items = try container.decodeIfPresent([UserDictionaryEntry].self, forKey: .items) ?? []
+                    self.dictionaries = [
+                        .init(name: "ユーザ辞書", isEnabled: true, items: items)
+                    ]
+                }
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(dictionaries, forKey: .dictionaries)
+            }
         }
 
         public var items: Value = Self.default
@@ -104,8 +152,10 @@ extension Config {
             self.items = items
         }
 
-        public static let `default`: Value = .init(items: [
-            .init(word: "azooKey", reading: "あずーきー", hint: "アプリ")
+        public static let `default`: Value = .init(dictionaries: [
+            .init(name: "ユーザ辞書", isEnabled: true, items: [
+                .init(word: "azooKey", reading: "あずーきー", hint: "アプリ")
+            ])
         ])
         public static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.user_dictionary_temporal2"
     }
@@ -124,6 +174,13 @@ extension Config {
 
         public static let `default`: Value = .init(items: [])
         public static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.system_user_dictionary"
+    }
+}
+
+extension Config.UserDictionary.Value {
+    enum CodingKeys: String, CodingKey {
+        case dictionaries
+        case items
     }
 }
 

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -1,6 +1,54 @@
 import Foundation
 import KanaKanjiConverterModuleWithDefaultDictionary
 
+private final class UserDictionaryIndexBuildRegistry: @unchecked Sendable {
+    struct Key: Hashable, Sendable {
+        var directoryPath: String
+        var userRevision: Int
+        var systemRevision: Int
+    }
+
+    static let shared = UserDictionaryIndexBuildRegistry()
+
+    private let lock = NSLock()
+    private var inProgressKeys: Set<Key> = []
+    private var inProgressDirectoryPaths: Set<String> = []
+    private var retryNotBeforeByKey: [Key: Date] = [:]
+    private let retryInterval: TimeInterval = 30
+
+    func start(_ key: Key) -> Bool {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        if inProgressKeys.contains(key) || inProgressDirectoryPaths.contains(key.directoryPath) {
+            return false
+        }
+        if let retryNotBefore = retryNotBeforeByKey[key],
+           retryNotBefore > Date() {
+            return false
+        }
+        retryNotBeforeByKey.removeValue(forKey: key)
+        inProgressKeys.insert(key)
+        inProgressDirectoryPaths.insert(key.directoryPath)
+        return true
+    }
+
+    func finish(_ key: Key, failed: Bool) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        inProgressKeys.remove(key)
+        inProgressDirectoryPaths.remove(key.directoryPath)
+        if failed {
+            retryNotBeforeByKey[key] = Date().addingTimeInterval(retryInterval)
+        } else {
+            retryNotBeforeByKey.removeValue(forKey: key)
+        }
+    }
+}
+
 public final class SegmentsManager {
     public init(
         kanaKanjiConverter: KanaKanjiConverter,
@@ -66,7 +114,7 @@ public final class SegmentsManager {
         self.applicationDirectoryURL.appendingPathComponent("UserDictionary", isDirectory: true)
     }
 
-    private struct DynamicUserDictionaryEntry {
+    private struct DynamicUserDictionaryEntry: Sendable {
         var deduplicationKey: String
         var ruby: String
         var element: DicdataElement
@@ -79,8 +127,10 @@ public final class SegmentsManager {
         var systemEntryCount: Int
         var userEntriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
         var systemEntriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
+        var dynamicFallbackEntriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
         var hints: [String: String]
         var hasIndexedDictionary: Bool
+        var hasLoadedIndexMetadata: Bool
     }
 
     public struct PredictionCandidate: Sendable, Equatable {
@@ -113,7 +163,10 @@ public final class SegmentsManager {
 
     private func annotationText(for candidate: Candidate) -> String? {
         candidate.data.lazy.compactMap {
-            self.userDictionaryHints[Self.userDictionaryHintKey(word: $0.word, ruby: $0.ruby)]
+            guard candidate.text == $0.word else {
+                return nil
+            }
+            return self.userDictionaryHints[Self.userDictionaryHintKey(word: $0.word, ruby: $0.ruby)]
         }.first
     }
 
@@ -127,6 +180,25 @@ public final class SegmentsManager {
         if let userDictionaryCache,
            userDictionaryCache.userRevision == userRevision,
            userDictionaryCache.systemRevision == systemRevision {
+            if !userDictionaryCache.hasLoadedIndexMetadata {
+                let allEntries = Self.entries(from: userDictionaryCache.userEntriesByFirstRubyCharacter)
+                    + Self.entries(from: userDictionaryCache.systemEntriesByFirstRubyCharacter)
+                let indexState = self.currentUserDictionaryIndexState(
+                    userRevision: userRevision,
+                    systemRevision: systemRevision,
+                    entries: allEntries
+                )
+                if indexState.hasLoadedIndexMetadata {
+                    var cache = userDictionaryCache
+                    cache.dynamicFallbackEntriesByFirstRubyCharacter = Self.entriesByFirstRubyCharacter(indexState.dynamicFallbackEntries)
+                    cache.hasIndexedDictionary = indexState.hasIndexedDictionary
+                    cache.hasLoadedIndexMetadata = true
+                    self.userDictionaryCache = cache
+                    self.userDictionaryHints = cache.hints
+                    self.userDictionaryIndexNeedsReload = true
+                    return cache
+                }
+            }
             self.userDictionaryHints = userDictionaryCache.hints
             return userDictionaryCache
         }
@@ -155,6 +227,12 @@ public final class SegmentsManager {
             }
             hints[Self.userDictionaryHintKey(word: item.word, ruby: item.reading.toKatakana())] = hint
         }
+        let allEntries = userEntries + systemEntries
+        let indexState = self.currentUserDictionaryIndexState(
+            userRevision: userRevision,
+            systemRevision: systemRevision,
+            entries: allEntries
+        )
         let cache = UserDictionaryCache(
             userRevision: userRevision,
             systemRevision: systemRevision,
@@ -162,8 +240,10 @@ public final class SegmentsManager {
             systemEntryCount: systemEntries.count,
             userEntriesByFirstRubyCharacter: Self.entriesByFirstRubyCharacter(userEntries),
             systemEntriesByFirstRubyCharacter: Self.entriesByFirstRubyCharacter(systemEntries),
+            dynamicFallbackEntriesByFirstRubyCharacter: Self.entriesByFirstRubyCharacter(indexState.dynamicFallbackEntries),
             hints: hints,
-            hasIndexedDictionary: self.rebuildUserDictionaryIndex(entries: userEntries + systemEntries)
+            hasIndexedDictionary: indexState.hasIndexedDictionary,
+            hasLoadedIndexMetadata: indexState.hasLoadedIndexMetadata
         )
         self.userDictionaryCache = cache
         self.userDictionaryHints = hints
@@ -172,27 +252,91 @@ public final class SegmentsManager {
         return cache
     }
 
-    private func rebuildUserDictionaryIndex(entries: [DynamicUserDictionaryEntry]) -> Bool {
-        do {
-            try UserDictionaryIndexStore(directoryURL: self.userDictionaryIndexDirectoryURL).rebuild(
-                entries: entries.map(\.element)
+    private func currentUserDictionaryIndexState(
+        userRevision: Int,
+        systemRevision: Int,
+        entries: [DynamicUserDictionaryEntry]
+    ) -> (hasIndexedDictionary: Bool, dynamicFallbackEntries: [DynamicUserDictionaryEntry], hasLoadedIndexMetadata: Bool) {
+        let store = UserDictionaryIndexStore(directoryURL: self.userDictionaryIndexDirectoryURL)
+        if let metadata = store.metadata(),
+           metadata.userRevision == userRevision,
+           metadata.systemRevision == systemRevision,
+           store.hasUsableIndex(for: metadata) {
+            let dynamicFallbackEntries = self.dynamicFallbackEntriesForIndexedDictionary(
+                entries: entries,
+                skippedEntryCount: metadata.skippedEntryCount
             )
-            self.userDictionaryIndexNeedsReload = true
-            return true
+            return (metadata.indexedEntryCount > 0, dynamicFallbackEntries, true)
+        }
+
+        self.startUserDictionaryIndexBuildIfNeeded(
+            userRevision: userRevision,
+            systemRevision: systemRevision,
+            entries: entries
+        )
+        return (false, entries, false)
+    }
+
+    private func dynamicFallbackEntriesForIndexedDictionary(
+        entries: [DynamicUserDictionaryEntry],
+        skippedEntryCount: Int
+    ) -> [DynamicUserDictionaryEntry] {
+        guard skippedEntryCount > 0 else {
+            return []
+        }
+        do {
+            let supportedCharacters = try UserDictionaryIndexStore.supportedCharacters()
+            return entries.filter {
+                !UserDictionaryIndexStore.canIndex(ruby: $0.ruby, supportedCharacters: supportedCharacters)
+            }
         } catch {
-            self.userDictionaryIndexNeedsReload = true
-            self.appendDebugMessage("userDictionaryIndexBuildError: \(error)")
-            return false
+            self.appendDebugMessage("userDictionaryIndexFallbackError: \(error)")
+            return entries
+        }
+    }
+
+    private func startUserDictionaryIndexBuildIfNeeded(
+        userRevision: Int,
+        systemRevision: Int,
+        entries: [DynamicUserDictionaryEntry]
+    ) {
+        let directoryURL = self.userDictionaryIndexDirectoryURL
+        let registryKey = UserDictionaryIndexBuildRegistry.Key(
+            directoryPath: directoryURL.path,
+            userRevision: userRevision,
+            systemRevision: systemRevision
+        )
+        guard UserDictionaryIndexBuildRegistry.shared.start(registryKey) else {
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async { [directoryURL, entries, registryKey] in
+            var didFail = false
+            do {
+                _ = try UserDictionaryIndexStore(directoryURL: directoryURL).rebuild(
+                    entries: entries.map(\.element),
+                    userRevision: userRevision,
+                    systemRevision: systemRevision
+                )
+            } catch {
+                didFail = true
+            }
+            UserDictionaryIndexBuildRegistry.shared.finish(registryKey, failed: didFail)
         }
     }
 
     private func dynamicUserDictionary(for queryRuby: String) -> [DicdataElement] {
         let cache = self.currentUserDictionaryCache()
-        guard !cache.hasIndexedDictionary else {
-            return []
-        }
         guard !queryRuby.isEmpty else {
             return []
+        }
+        let entriesByFirstRubyCharacter = if cache.hasIndexedDictionary {
+            cache.dynamicFallbackEntriesByFirstRubyCharacter
+        } else {
+            Self.mergeEntriesByFirstRubyCharacter(
+                cache.userEntriesByFirstRubyCharacter,
+                cache.systemEntriesByFirstRubyCharacter
+            )
         }
         var elements: [DicdataElement] = []
         var seenKeys: Set<String> = []
@@ -201,8 +345,7 @@ public final class SegmentsManager {
             guard let firstRubyCharacter = suffix.first else {
                 continue
             }
-            let entries = (cache.userEntriesByFirstRubyCharacter[firstRubyCharacter] ?? [])
-                + (cache.systemEntriesByFirstRubyCharacter[firstRubyCharacter] ?? [])
+            let entries = entriesByFirstRubyCharacter[firstRubyCharacter] ?? []
             for entry in entries where Self.dynamicUserDictionaryEntryRuby(entry.ruby, matchesQuerySuffix: suffix) {
                 if seenKeys.insert(entry.deduplicationKey).inserted {
                     elements.append(entry.element)
@@ -220,6 +363,21 @@ public final class SegmentsManager {
                 return
             }
             result[firstRubyCharacter, default: []].append(entry)
+        }
+    }
+
+    private static func entries(
+        from entriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
+    ) -> [DynamicUserDictionaryEntry] {
+        entriesByFirstRubyCharacter.values.flatMap(\.self)
+    }
+
+    private static func mergeEntriesByFirstRubyCharacter(
+        _ lhs: [Character: [DynamicUserDictionaryEntry]],
+        _ rhs: [Character: [DynamicUserDictionaryEntry]]
+    ) -> [Character: [DynamicUserDictionaryEntry]] {
+        rhs.reduce(into: lhs) { result, item in
+            result[item.key, default: []].append(contentsOf: item.value)
         }
     }
 

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -36,12 +36,6 @@ public final class SegmentsManager {
     private var liveConversionEnabled: Bool {
         Config.LiveConversion().value
     }
-    private var userDictionary: Config.UserDictionary.Value {
-        Config.UserDictionary().value
-    }
-    private var systemUserDictionary: Config.SystemUserDictionary.Value {
-        Config.SystemUserDictionary().value
-    }
     private var zenzaiPersonalizationLevel: Config.ZenzaiPersonalizationLevel.Value {
         Config.ZenzaiPersonalizationLevel().value
     }
@@ -64,6 +58,30 @@ public final class SegmentsManager {
     private var suggestSelectionIndex: Int?
     private var backspaceAdjustedPredictionCandidate: PredictionCandidate?
     private var backspaceTypoCorrectionLock: BackspaceTypoCorrectionLock?
+    private var userDictionaryHints: [String: String] = [:]
+    private var userDictionaryCache: UserDictionaryCache?
+    private var userDictionaryIndexNeedsReload = true
+
+    private var userDictionaryIndexDirectoryURL: URL {
+        self.applicationDirectoryURL.appendingPathComponent("UserDictionary", isDirectory: true)
+    }
+
+    private struct DynamicUserDictionaryEntry {
+        var deduplicationKey: String
+        var ruby: String
+        var element: DicdataElement
+    }
+
+    private struct UserDictionaryCache {
+        var userRevision: Int
+        var systemRevision: Int
+        var userEntryCount: Int
+        var systemEntryCount: Int
+        var userEntriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
+        var systemEntriesByFirstRubyCharacter: [Character: [DynamicUserDictionaryEntry]]
+        var hints: [String: String]
+        var hasIndexedDictionary: Bool
+    }
 
     public struct PredictionCandidate: Sendable, Equatable {
         public var displayText: String
@@ -86,8 +104,164 @@ public final class SegmentsManager {
             if index < additionalPresentations.count {
                 return .init(candidate: candidates[index], displayContext: additionalPresentations[index].displayContext)
             }
-            return .init(candidate: candidates[index])
+            return .init(
+                candidate: candidates[index],
+                displayContext: .init(annotationText: self.annotationText(for: candidates[index]))
+            )
         }
+    }
+
+    private func annotationText(for candidate: Candidate) -> String? {
+        candidate.data.lazy.compactMap {
+            self.userDictionaryHints[Self.userDictionaryHintKey(word: $0.word, ruby: $0.ruby)]
+        }.first
+    }
+
+    private static func userDictionaryHintKey(word: String, ruby: String) -> String {
+        "\(ruby)\u{1F}\(word)"
+    }
+
+    private func currentUserDictionaryCache() -> UserDictionaryCache {
+        let userRevision = UserDefaults.standard.integer(forKey: Config.UserDictionary.revisionKey)
+        let systemRevision = UserDefaults.standard.integer(forKey: Config.SystemUserDictionary.revisionKey)
+        if let userDictionaryCache,
+           userDictionaryCache.userRevision == userRevision,
+           userDictionaryCache.systemRevision == systemRevision {
+            self.userDictionaryHints = userDictionaryCache.hints
+            return userDictionaryCache
+        }
+
+        let userDictionary = Config.UserDictionary().value
+        let enabledItems = userDictionary.enabledItems
+        let userEntries = enabledItems.map { item in
+            let ruby = item.reading.toKatakana()
+            return DynamicUserDictionaryEntry(
+                deduplicationKey: "user:\(item.id.uuidString)",
+                ruby: ruby,
+                element: .init(word: item.word, ruby: ruby, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+            )
+        }
+        let systemEntries = Config.SystemUserDictionary().value.items.map { item in
+            let ruby = item.reading.toKatakana()
+            return DynamicUserDictionaryEntry(
+                deduplicationKey: "system:\(item.id.uuidString)",
+                ruby: ruby,
+                element: .init(word: item.word, ruby: ruby, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+            )
+        }
+        let hints = enabledItems.reduce(into: [String: String]()) { hints, item in
+            guard let hint = item.hint, !hint.isEmpty else {
+                return
+            }
+            hints[Self.userDictionaryHintKey(word: item.word, ruby: item.reading.toKatakana())] = hint
+        }
+        let cache = UserDictionaryCache(
+            userRevision: userRevision,
+            systemRevision: systemRevision,
+            userEntryCount: userEntries.count,
+            systemEntryCount: systemEntries.count,
+            userEntriesByFirstRubyCharacter: Self.entriesByFirstRubyCharacter(userEntries),
+            systemEntriesByFirstRubyCharacter: Self.entriesByFirstRubyCharacter(systemEntries),
+            hints: hints,
+            hasIndexedDictionary: self.rebuildUserDictionaryIndex(entries: userEntries + systemEntries)
+        )
+        self.userDictionaryCache = cache
+        self.userDictionaryHints = hints
+        self.appendDebugMessage("userDictionaryCount: \(cache.userEntryCount)")
+        self.appendDebugMessage("systemUserDictionaryCount: \(cache.systemEntryCount)")
+        return cache
+    }
+
+    private func rebuildUserDictionaryIndex(entries: [DynamicUserDictionaryEntry]) -> Bool {
+        do {
+            try UserDictionaryIndexStore(directoryURL: self.userDictionaryIndexDirectoryURL).rebuild(
+                entries: entries.map(\.element)
+            )
+            self.userDictionaryIndexNeedsReload = true
+            return true
+        } catch {
+            self.userDictionaryIndexNeedsReload = true
+            self.appendDebugMessage("userDictionaryIndexBuildError: \(error)")
+            return false
+        }
+    }
+
+    private func dynamicUserDictionary(for queryRuby: String) -> [DicdataElement] {
+        let cache = self.currentUserDictionaryCache()
+        guard !cache.hasIndexedDictionary else {
+            return []
+        }
+        guard !queryRuby.isEmpty else {
+            return []
+        }
+        var elements: [DicdataElement] = []
+        var seenKeys: Set<String> = []
+        for suffixStart in queryRuby.indices {
+            let suffix = String(queryRuby[suffixStart...])
+            guard let firstRubyCharacter = suffix.first else {
+                continue
+            }
+            let entries = (cache.userEntriesByFirstRubyCharacter[firstRubyCharacter] ?? [])
+                + (cache.systemEntriesByFirstRubyCharacter[firstRubyCharacter] ?? [])
+            for entry in entries where Self.dynamicUserDictionaryEntryRuby(entry.ruby, matchesQuerySuffix: suffix) {
+                if seenKeys.insert(entry.deduplicationKey).inserted {
+                    elements.append(entry.element)
+                }
+            }
+        }
+        return elements
+    }
+
+    private static func entriesByFirstRubyCharacter(
+        _ entries: [DynamicUserDictionaryEntry]
+    ) -> [Character: [DynamicUserDictionaryEntry]] {
+        entries.reduce(into: [Character: [DynamicUserDictionaryEntry]]()) { result, entry in
+            guard let firstRubyCharacter = entry.ruby.first else {
+                return
+            }
+            result[firstRubyCharacter, default: []].append(entry)
+        }
+    }
+
+    static func shouldIncludeDynamicUserDictionaryEntry(ruby entryRuby: String, for queryRuby: String) -> Bool {
+        guard !entryRuby.isEmpty, !queryRuby.isEmpty else {
+            return false
+        }
+        return queryRuby.indices.contains { suffixStart in
+            let suffix = String(queryRuby[suffixStart...])
+            return Self.dynamicUserDictionaryEntryRuby(entryRuby, matchesQuerySuffix: suffix)
+        }
+    }
+
+    private static func dynamicUserDictionaryEntryRuby(_ entryRuby: String, matchesQuerySuffix suffix: String) -> Bool {
+        entryRuby.hasPrefix(suffix) || suffix.hasPrefix(entryRuby)
+    }
+
+    private static func makeDynamicShortcuts() -> [DicdataElement] {
+        [
+            ("M/d", -18, DateTemplateLiteral.CalendarType.western),
+            ("yyyy/MM/dd", -18.1, .western),
+            ("yyyy-MM-dd", -18.2, .western),
+            ("M月d日（E）", -18.3, .western),
+            ("yyyy年M月d日", -18.4, .western),
+            ("Gyyyy年M月d日", -18.5, .japanese),
+            ("E曜日", -18.6, .western)
+        ].flatMap { (format, value: PValue, type) in
+            [
+                .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "-2", deltaUnit: 60 * 60 * 24).export(), ruby: "オトトイ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
+                .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "-1", deltaUnit: 60 * 60 * 24).export(), ruby: "キノウ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
+                .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "キョウ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
+                .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "1", deltaUnit: 60 * 60 * 24).export(), ruby: "アシタ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
+                .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "2", deltaUnit: 60 * 60 * 24).export(), ruby: "アサッテ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value)
+            ]
+        } + [
+            .init(word: DateTemplateLiteral(format: "MM月", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コンゲツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
+            .init(word: DateTemplateLiteral(format: "yyyy年", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コトシ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
+            .init(word: DateTemplateLiteral(format: "Gyyyy年", type: .japanese, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コトシ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.1),
+            .init(word: DateTemplateLiteral(format: "HH:mm", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
+            .init(word: DateTemplateLiteral(format: "HH時mm分", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.1),
+            .init(word: DateTemplateLiteral(format: "aK時mm分", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.2)
+        ]
     }
 
     private lazy var zenzaiPersonalizationMode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode? = self.getZenzaiPersonalizationMode()
@@ -185,7 +359,7 @@ public final class SegmentsManager {
             fullWidthRomanCandidate: true,
             learningType: Config.Learning().value.learningType,
             memoryDirectoryURL: self.azooKeyMemoryDir,
-            sharedContainerURL: self.azooKeyMemoryDir,
+            sharedContainerURL: self.userDictionaryIndexDirectoryURL,
             textReplacer: .withDefaultEmojiDictionary(),
             specialCandidateProviders: KanaKanjiConverter.defaultSpecialCandidateProviders,
             zenzaiMode: self.zenzaiMode(leftSideContext: leftSideContext, requestRichCandidates: requestRichCandidates),
@@ -480,50 +654,16 @@ public final class SegmentsManager {
             self.kanaKanjiConverter.stopComposition()
             return
         }
-        // ユーザ辞書情報の更新
-        var userDictionary: [DicdataElement] = userDictionary.items.map {
-            .init(word: $0.word, ruby: $0.reading.toKatakana(), cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
-        }
-        self.appendDebugMessage("userDictionaryCount: \(userDictionary.count)")
-        let systemUserDictionary: [DicdataElement] = systemUserDictionary.items.map {
-            .init(word: $0.word, ruby: $0.reading.toKatakana(), cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
-        }
-        self.appendDebugMessage("systemUserDictionaryCount: \(systemUserDictionary.count)")
-        userDictionary.append(contentsOf: consume systemUserDictionary)
-
-        /// 日付・時刻変換を事前に入れておく
-        let dynamicShortcuts: [DicdataElement] =
-            [
-                ("M/d", -18, DateTemplateLiteral.CalendarType.western),
-                ("yyyy/MM/dd", -18.1, .western),
-                ("yyyy-MM-dd", -18.2, .western),
-                ("M月d日（E）", -18.3, .western),
-                ("yyyy年M月d日", -18.4, .western),
-                ("Gyyyy年M月d日", -18.5, .japanese),
-                ("E曜日", -18.6, .western)
-            ].flatMap { (format, value: PValue, type) in
-                [
-                    .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "-2", deltaUnit: 60 * 60 * 24).export(), ruby: "オトトイ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
-                    .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "-1", deltaUnit: 60 * 60 * 24).export(), ruby: "キノウ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
-                    .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "キョウ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
-                    .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "1", deltaUnit: 60 * 60 * 24).export(), ruby: "アシタ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value),
-                    .init(word: DateTemplateLiteral(format: format, type: type, language: .japanese, delta: "2", deltaUnit: 60 * 60 * 24).export(), ruby: "アサッテ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: value)
-                ]
-            } + [
-                // 月
-                .init(word: DateTemplateLiteral(format: "MM月", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コンゲツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
-                // 年
-                .init(word: DateTemplateLiteral(format: "yyyy年", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コトシ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
-                .init(word: DateTemplateLiteral(format: "Gyyyy年", type: .japanese, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "コトシ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.1),
-                // 時刻
-                .init(word: DateTemplateLiteral(format: "HH:mm", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18),
-                .init(word: DateTemplateLiteral(format: "HH時mm分", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.1),
-                .init(word: DateTemplateLiteral(format: "aK時mm分", type: .western, language: .japanese, delta: "0", deltaUnit: 1).export(), ruby: "イマ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -18.2)
-            ]
-
-        self.kanaKanjiConverter.importDynamicUserDictionary(consume userDictionary, shortcuts: dynamicShortcuts)
-
         let prefixComposingText = self.composingText.prefixToCursorPosition()
+        let queryRuby = prefixComposingText.convertTarget.toKatakana()
+        let userDictionary = self.dynamicUserDictionary(for: queryRuby)
+        self.kanaKanjiConverter.updateUserDictionaryURL(
+            self.userDictionaryIndexDirectoryURL,
+            forceReload: self.userDictionaryIndexNeedsReload
+        )
+        self.userDictionaryIndexNeedsReload = false
+        self.kanaKanjiConverter.importDynamicUserDictionary(userDictionary, shortcuts: Self.makeDynamicShortcuts())
+
         let leftSideContext = forcedLeftSideContext ?? self.getCleanLeftSideContext(maxCount: 30)
         let result = self.kanaKanjiConverter.requestCandidates(
             prefixComposingText,

--- a/Core/Sources/Core/UserDictionary/UserDictionaryIndexStore.swift
+++ b/Core/Sources/Core/UserDictionary/UserDictionaryIndexStore.swift
@@ -1,14 +1,147 @@
 import Foundation
 import KanaKanjiConverterModuleWithDefaultDictionary
 
+public struct UserDictionaryIndexBuildResult: Sendable, Equatable {
+    public var indexedEntryCount: Int
+    public var skippedEntryCount: Int
+    public var totalEntryCount: Int
+}
+
+public struct UserDictionaryIndexSummary: Sendable, Equatable {
+    public var userRevision: Int
+    public var systemRevision: Int
+    public var indexedEntryCount: Int
+    public var skippedEntryCount: Int
+    public var totalEntryCount: Int
+    public var updatedAt: Date?
+}
+
+public enum UserDictionaryIndexStatus: Sendable, Equatable {
+    case notBuilt(entryCount: Int)
+    case ready(UserDictionaryIndexSummary)
+    case needsRebuild(currentEntryCount: Int, existing: UserDictionaryIndexSummary?)
+}
+
+public enum UserDictionaryIndexController {
+    public static func indexDirectoryURL(applicationDirectoryURL: URL) -> URL {
+        applicationDirectoryURL.appendingPathComponent("UserDictionary", isDirectory: true)
+    }
+
+    public static func currentStatus(applicationDirectoryURL: URL) -> UserDictionaryIndexStatus {
+        Self.status(
+            directoryURL: Self.indexDirectoryURL(applicationDirectoryURL: applicationDirectoryURL),
+            currentUserRevision: UserDefaults.standard.integer(forKey: Config.UserDictionary.revisionKey),
+            currentSystemRevision: UserDefaults.standard.integer(forKey: Config.SystemUserDictionary.revisionKey),
+            entryCount: Self.currentEntries().count
+        )
+    }
+
+    public static func rebuild(applicationDirectoryURL: URL) throws -> UserDictionaryIndexBuildResult {
+        let entries = Self.currentEntries()
+        let result = try UserDictionaryIndexStore(
+            directoryURL: Self.indexDirectoryURL(applicationDirectoryURL: applicationDirectoryURL)
+        ).rebuild(
+            entries: entries,
+            userRevision: UserDefaults.standard.integer(forKey: Config.UserDictionary.revisionKey),
+            systemRevision: UserDefaults.standard.integer(forKey: Config.SystemUserDictionary.revisionKey)
+        )
+        return .init(
+            indexedEntryCount: result.indexedEntryCount,
+            skippedEntryCount: result.skippedEntryCount,
+            totalEntryCount: entries.count
+        )
+    }
+
+    static func status(
+        directoryURL: URL,
+        currentUserRevision: Int,
+        currentSystemRevision: Int,
+        entryCount: Int
+    ) -> UserDictionaryIndexStatus {
+        let store = UserDictionaryIndexStore(directoryURL: directoryURL)
+        guard let metadata = store.metadata() else {
+            return .notBuilt(entryCount: entryCount)
+        }
+        let summary = UserDictionaryIndexSummary(
+            userRevision: metadata.userRevision,
+            systemRevision: metadata.systemRevision,
+            indexedEntryCount: metadata.indexedEntryCount,
+            skippedEntryCount: metadata.skippedEntryCount,
+            totalEntryCount: metadata.indexedEntryCount + metadata.skippedEntryCount,
+            updatedAt: Self.metadataModificationDate(directoryURL: directoryURL)
+        )
+        if metadata.userRevision == currentUserRevision,
+           metadata.systemRevision == currentSystemRevision,
+           store.hasUsableIndex(for: metadata) {
+            return .ready(summary)
+        }
+        return .needsRebuild(currentEntryCount: entryCount, existing: summary)
+    }
+
+    private static func currentEntries() -> [DicdataElement] {
+        let userEntries = Config.UserDictionary().value.enabledItems.map { item in
+            let ruby = item.reading.toKatakana()
+            return DicdataElement(word: item.word, ruby: ruby, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        }
+        let systemEntries = Config.SystemUserDictionary().value.items.map { item in
+            let ruby = item.reading.toKatakana()
+            return DicdataElement(word: item.word, ruby: ruby, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        }
+        return userEntries + systemEntries
+    }
+
+    private static func metadataModificationDate(directoryURL: URL) -> Date? {
+        let metadataURL = directoryURL.appendingPathComponent("metadata.json", isDirectory: false)
+        let attributes = try? FileManager.default.attributesOfItem(atPath: metadataURL.path)
+        return attributes?[.modificationDate] as? Date
+    }
+}
+
 struct UserDictionaryIndexStore {
     enum BuildError: Error {
         case missingCharIDFile
     }
 
+    struct RebuildResult {
+        var indexedEntryCount: Int
+        var skippedEntryCount: Int
+    }
+
+    struct Metadata: Codable, Equatable {
+        var userRevision: Int
+        var systemRevision: Int
+        var indexedEntryCount: Int
+        var skippedEntryCount: Int
+    }
+
     let directoryURL: URL
 
-    func rebuild(entries: [DicdataElement]) throws {
+    private var metadataURL: URL {
+        directoryURL.appendingPathComponent("metadata.json", isDirectory: false)
+    }
+
+    func metadata() -> Metadata? {
+        guard let data = try? Data(contentsOf: metadataURL) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(Metadata.self, from: data)
+    }
+
+    func hasUsableIndex(for metadata: Metadata) -> Bool {
+        guard metadata.indexedEntryCount > 0 else {
+            return true
+        }
+        let requiredFileNames = [
+            "user.louds",
+            "user.loudschars2",
+            "user0.loudstxt3"
+        ]
+        return requiredFileNames.allSatisfy {
+            FileManager.default.fileExists(atPath: directoryURL.appendingPathComponent($0, isDirectory: false).path)
+        }
+    }
+
+    func rebuild(entries: [DicdataElement], userRevision: Int, systemRevision: Int) throws -> RebuildResult {
         let fileManager = FileManager.default
         let parentURL = directoryURL.deletingLastPathComponent()
         try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
@@ -20,12 +153,30 @@ struct UserDictionaryIndexStore {
         try fileManager.createDirectory(at: temporaryURL, withIntermediateDirectories: true)
 
         do {
-            if !entries.isEmpty {
+            let indexableEntries: [DicdataElement]
+            if entries.isEmpty {
+                indexableEntries = []
+            } else {
                 guard let charIDFileURL = Self.defaultCharIDFileURL() else {
                     throw BuildError.missingCharIDFile
                 }
+                let supportedCharacters = try Self.supportedCharacters(from: charIDFileURL)
+                indexableEntries = entries.filter {
+                    Self.canIndex(ruby: $0.ruby, supportedCharacters: supportedCharacters)
+                }
+                guard !indexableEntries.isEmpty else {
+                    if fileManager.fileExists(atPath: directoryURL.path) {
+                        try fileManager.removeItem(at: directoryURL)
+                    }
+                    try Self.writeMetadata(
+                        .init(userRevision: userRevision, systemRevision: systemRevision, indexedEntryCount: 0, skippedEntryCount: entries.count),
+                        to: temporaryURL
+                    )
+                    try fileManager.moveItem(at: temporaryURL, to: directoryURL)
+                    return .init(indexedEntryCount: 0, skippedEntryCount: entries.count)
+                }
                 try DictionaryBuilder.exportDictionary(
-                    entries: entries,
+                    entries: indexableEntries,
                     to: temporaryURL,
                     baseName: "user",
                     shardByFirstCharacter: false,
@@ -36,11 +187,33 @@ struct UserDictionaryIndexStore {
             if fileManager.fileExists(atPath: directoryURL.path) {
                 try fileManager.removeItem(at: directoryURL)
             }
+            let result = RebuildResult(indexedEntryCount: indexableEntries.count, skippedEntryCount: entries.count - indexableEntries.count)
+            try Self.writeMetadata(
+                .init(
+                    userRevision: userRevision,
+                    systemRevision: systemRevision,
+                    indexedEntryCount: result.indexedEntryCount,
+                    skippedEntryCount: result.skippedEntryCount
+                ),
+                to: temporaryURL
+            )
             try fileManager.moveItem(at: temporaryURL, to: directoryURL)
+            return result
         } catch {
             try? fileManager.removeItem(at: temporaryURL)
             throw error
         }
+    }
+
+    static func supportedCharacters() throws -> Set<Character> {
+        guard let charIDFileURL = Self.defaultCharIDFileURL() else {
+            throw BuildError.missingCharIDFile
+        }
+        return try Self.supportedCharacters(from: charIDFileURL)
+    }
+
+    static func canIndex(ruby: String, supportedCharacters: Set<Character>) -> Bool {
+        !ruby.isEmpty && ruby.allSatisfy { supportedCharacters.contains($0) }
     }
 
     private static func defaultCharIDFileURL() -> URL? {
@@ -54,5 +227,15 @@ struct UserDictionaryIndexStore {
             .first {
                 FileManager.default.fileExists(atPath: $0.path)
             }
+    }
+
+    private static func supportedCharacters(from charIDFileURL: URL) throws -> Set<Character> {
+        let text = try String(contentsOf: charIDFileURL, encoding: .utf8)
+        return Set(text)
+    }
+
+    private static func writeMetadata(_ metadata: Metadata, to directoryURL: URL) throws {
+        let data = try JSONEncoder().encode(metadata)
+        try data.write(to: directoryURL.appendingPathComponent("metadata.json", isDirectory: false))
     }
 }

--- a/Core/Sources/Core/UserDictionary/UserDictionaryIndexStore.swift
+++ b/Core/Sources/Core/UserDictionary/UserDictionaryIndexStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import KanaKanjiConverterModuleWithDefaultDictionary
+
+struct UserDictionaryIndexStore {
+    enum BuildError: Error {
+        case missingCharIDFile
+    }
+
+    let directoryURL: URL
+
+    func rebuild(entries: [DicdataElement]) throws {
+        let fileManager = FileManager.default
+        let parentURL = directoryURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+
+        let temporaryURL = parentURL.appendingPathComponent(
+            "\(directoryURL.lastPathComponent).building-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: temporaryURL, withIntermediateDirectories: true)
+
+        do {
+            if !entries.isEmpty {
+                guard let charIDFileURL = Self.defaultCharIDFileURL() else {
+                    throw BuildError.missingCharIDFile
+                }
+                try DictionaryBuilder.exportDictionary(
+                    entries: entries,
+                    to: temporaryURL,
+                    baseName: "user",
+                    shardByFirstCharacter: false,
+                    charIDFileURL: charIDFileURL
+                )
+            }
+
+            if fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.removeItem(at: directoryURL)
+            }
+            try fileManager.moveItem(at: temporaryURL, to: directoryURL)
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+    }
+
+    private static func defaultCharIDFileURL() -> URL? {
+        _ = DicdataStore.withDefaultDictionary(preloadDictionary: false)
+        return (Bundle.allBundles + Bundle.allFrameworks)
+            .lazy
+            .compactMap(\.resourceURL)
+            .map {
+                $0.appendingPathComponent("Dictionary/louds/charID.chid", isDirectory: false)
+            }
+            .first {
+                FileManager.default.fileExists(atPath: $0.path)
+            }
+    }
+}

--- a/Core/Sources/Core/UserDictionary/UserDictionaryTextFormat.swift
+++ b/Core/Sources/Core/UserDictionary/UserDictionaryTextFormat.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+public enum UserDictionaryTextFormat: String, CaseIterable, Identifiable, Sendable {
+    case automatic
+    case googleJapaneseInput
+    case msime
+    case atok
+    case kotoeri
+
+    public var id: String {
+        rawValue
+    }
+
+    public var localizedName: String {
+        switch self {
+        case .automatic:
+            "自動判定"
+        case .googleJapaneseInput:
+            "Google日本語入力 / Mozc"
+        case .msime:
+            "Microsoft IME"
+        case .atok:
+            "ATOK"
+        case .kotoeri:
+            "ことえり"
+        }
+    }
+}
+
+public struct UserDictionaryImportResult: Sendable {
+    public var dictionaryName: String?
+    public var entries: [Config.UserDictionaryEntry]
+    public var skippedLineCount: Int
+
+    public init(dictionaryName: String?, entries: [Config.UserDictionaryEntry], skippedLineCount: Int) {
+        self.dictionaryName = dictionaryName
+        self.entries = entries
+        self.skippedLineCount = skippedLineCount
+    }
+}
+
+public enum UserDictionaryTextCodec {
+    public static func decodeText(from data: Data) -> String? {
+        if data.starts(with: [0xEF, 0xBB, 0xBF]) {
+            return String(data: Data(data.dropFirst(3)), encoding: .utf8)
+        }
+        if data.starts(with: [0xFF, 0xFE]) {
+            return String(data: data, encoding: .utf16LittleEndian)
+        }
+        if data.starts(with: [0xFE, 0xFF]) {
+            return String(data: data, encoding: .utf16BigEndian)
+        }
+        return String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .shiftJIS)
+            ?? String(data: data, encoding: .utf16)
+    }
+
+    public static func importEntries(
+        from text: String,
+        format requestedFormat: UserDictionaryTextFormat = .automatic
+    ) -> UserDictionaryImportResult {
+        let lines = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+        let format = requestedFormat == .automatic ? guessFormat(from: lines) : requestedFormat
+        var dictionaryName: String?
+        var entries: [Config.UserDictionaryEntry] = []
+        var skippedLineCount = 0
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                continue
+            }
+            if let name = dictionaryNameHeader(in: trimmed) {
+                dictionaryName = name
+                continue
+            }
+            guard !isCommentOrHeader(trimmed, format: format) else {
+                continue
+            }
+
+            let columns: [String]
+            switch format {
+            case .kotoeri:
+                columns = splitCSV(trimmed)
+            case .automatic, .googleJapaneseInput, .msime, .atok:
+                columns = line.components(separatedBy: "\t")
+            }
+
+            guard columns.count >= 3 else {
+                skippedLineCount += 1
+                continue
+            }
+            let reading = columns[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let word = columns[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            let hint = columns.count >= 4 ? normalizedHint(columns[3]) : nil
+            guard !reading.isEmpty, !word.isEmpty else {
+                skippedLineCount += 1
+                continue
+            }
+            entries.append(.init(word: word, reading: reading, hint: hint))
+        }
+
+        return .init(dictionaryName: dictionaryName, entries: entries, skippedLineCount: skippedLineCount)
+    }
+
+    public static func exportEntries(_ entries: [Config.UserDictionaryEntry], dictionaryName: String) -> String {
+        let header = [
+            "!Dictionary File",
+            "!Version: 1.0",
+            "!User Dictionary Name: \(dictionaryName)"
+        ]
+        let body = entries.map { entry in
+            [
+                sanitizeField(entry.reading),
+                sanitizeField(entry.word),
+                "名詞",
+                sanitizeField(entry.hint ?? "")
+            ].joined(separator: "\t")
+        }
+        return (header + body).joined(separator: "\n") + "\n"
+    }
+
+    private static func dictionaryNameHeader(in line: String) -> String? {
+        let prefix = "!User Dictionary Name:"
+        guard line.hasPrefix(prefix) else {
+            return nil
+        }
+        let name = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+
+    private static func isCommentOrHeader(_ line: String, format: UserDictionaryTextFormat) -> Bool {
+        switch format {
+        case .msime, .atok:
+            line.hasPrefix("!")
+        case .googleJapaneseInput, .automatic:
+            line.hasPrefix("!") || line.hasPrefix("#")
+        case .kotoeri:
+            line.hasPrefix("//")
+        }
+    }
+
+    private static func guessFormat(from lines: [String]) -> UserDictionaryTextFormat {
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                continue
+            }
+            let lower = trimmed.lowercased()
+            if lower.hasPrefix("!microsoft ime") {
+                return .msime
+            }
+            if lower.hasPrefix("!!dicut") || lower.hasPrefix("!!atok_tango_text_header") {
+                return .atok
+            }
+            if trimmed.hasPrefix("\""), trimmed.hasSuffix("\""), !trimmed.contains("\t") {
+                return .kotoeri
+            }
+            if trimmed.hasPrefix("#") || trimmed.contains("\t") || trimmed.hasPrefix("!") {
+                return .googleJapaneseInput
+            }
+        }
+        return .googleJapaneseInput
+    }
+
+    private static func normalizedHint(_ value: String) -> String? {
+        let hint = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return hint.isEmpty ? nil : hint
+    }
+
+    private static func sanitizeField(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\t", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+
+    private static func splitCSV(_ line: String) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var inQuotes = false
+        var index = line.startIndex
+        while index < line.endIndex {
+            let character = line[index]
+            if character == "\"" {
+                let nextIndex = line.index(after: index)
+                if inQuotes, nextIndex < line.endIndex, line[nextIndex] == "\"" {
+                    current.append("\"")
+                    index = nextIndex
+                } else {
+                    inQuotes.toggle()
+                }
+            } else if character == ",", !inQuotes {
+                fields.append(current)
+                current = ""
+            } else {
+                current.append(character)
+            }
+            index = line.index(after: index)
+        }
+        fields.append(current)
+        return fields
+    }
+}

--- a/Core/Sources/Core/UserDictionary/UserDictionaryTextFormat.swift
+++ b/Core/Sources/Core/UserDictionary/UserDictionaryTextFormat.swift
@@ -45,10 +45,10 @@ public enum UserDictionaryTextCodec {
             return String(data: Data(data.dropFirst(3)), encoding: .utf8)
         }
         if data.starts(with: [0xFF, 0xFE]) {
-            return String(data: data, encoding: .utf16LittleEndian)
+            return String(data: Data(data.dropFirst(2)), encoding: .utf16LittleEndian)
         }
         if data.starts(with: [0xFE, 0xFF]) {
-            return String(data: data, encoding: .utf16BigEndian)
+            return String(data: Data(data.dropFirst(2)), encoding: .utf16BigEndian)
         }
         return String(data: data, encoding: .utf8)
             ?? String(data: data, encoding: .shiftJIS)

--- a/Core/Tests/CoreTests/InputUtilsTests/SegmentsManagerAdditionalCandidatesTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/SegmentsManagerAdditionalCandidatesTests.swift
@@ -120,3 +120,67 @@ private func makeEditedRangeScenario() -> (manager: SegmentsManager, selectedRub
         Issue.record("Expected selecting state after expanding additional candidates.")
     }
 }
+
+@MainActor
+@Test func userDictionaryAnnotationRequiresDisplayedCandidateTextToMatchEntryWord() async throws {
+    let defaults = UserDefaults.standard
+    let key = Config.UserDictionary.key
+    let revisionKey = Config.UserDictionary.revisionKey
+    let oldData = defaults.data(forKey: key)
+    let oldRevision = defaults.object(forKey: revisionKey)
+    defer {
+        if let oldData {
+            defaults.set(oldData, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        if let oldRevision {
+            defaults.set(oldRevision, forKey: revisionKey)
+        } else {
+            defaults.removeObject(forKey: revisionKey)
+        }
+    }
+
+    defaults.removeObject(forKey: key)
+    defaults.removeObject(forKey: revisionKey)
+    Config.UserDictionary().value = .init(dictionaries: [
+        .init(
+            name: "数学",
+            items: [
+                .init(word: "Gorenstein", reading: "ごれんしゅたいん", hint: "Gorenstein 環などで知られる数学者")
+            ]
+        )
+    ])
+
+    let manager = makeSegmentsManager()
+    manager.insertAtCursorPosition("ごれんしゅたいん", inputStyle: .direct)
+    manager.update(requestRichCandidates: false)
+
+    let data = [
+        DicdataElement(
+            word: "Gorenstein",
+            ruby: "ゴレンシュタイン",
+            cid: CIDData.固有名詞.cid,
+            mid: MIDData.一般.mid,
+            value: -5
+        )
+    ]
+    let exactCandidate = Candidate(
+        text: "Gorenstein",
+        value: .zero,
+        composingCount: .inputCount(8),
+        lastMid: MIDData.一般.mid,
+        data: data
+    )
+    let unrelatedSurfaceCandidate = Candidate(
+        text: "ご恋シュタイン",
+        value: .zero,
+        composingCount: .inputCount(8),
+        lastMid: MIDData.一般.mid,
+        data: data
+    )
+
+    let presentations = manager.makeCandidatePresentations([exactCandidate, unrelatedSurfaceCandidate])
+    #expect(presentations[0].displayContext.annotationText == "Gorenstein 環などで知られる数学者")
+    #expect(presentations[1].displayContext.annotationText == nil)
+}

--- a/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTextFormatTests.swift
+++ b/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTextFormatTests.swift
@@ -1,0 +1,90 @@
+@testable import Core
+import Foundation
+import KanaKanjiConverterModuleWithDefaultDictionary
+import Testing
+
+@Test func importGoogleJapaneseInputTSVWithComments() {
+    let text = """
+    !Dictionary File
+    !Version: 1.0
+    !User Dictionary Name: 化学統合版
+    くろむこう\tCr鋼\t名詞\tCrを特徴とする鋼材。
+    えんそいおん\tClイオン\t名詞\tClイの電荷を持つイオン。
+    こめなし\tコメントなし\t名詞
+    """
+
+    let result = UserDictionaryTextCodec.importEntries(from: text, format: .automatic)
+
+    #expect(result.dictionaryName == "化学統合版")
+    #expect(result.entries.count == 3)
+    #expect(result.entries[0].reading == "くろむこう")
+    #expect(result.entries[0].word == "Cr鋼")
+    #expect(result.entries[0].hint == "Crを特徴とする鋼材。")
+    #expect(result.entries[2].hint == nil)
+}
+
+@Test func exportGoogleJapaneseInputTSV() {
+    let entries = [
+        Config.UserDictionaryEntry(word: "Cohen-Macaulay", reading: "こーえんまこーれー", hint: "深さが Krull 次元に等しいことを表す性質"),
+        Config.UserDictionaryEntry(word: "正則列", reading: "せいそくれつ", hint: nil)
+    ]
+
+    let exported = UserDictionaryTextCodec.exportEntries(entries, dictionaryName: "可換環論")
+
+    #expect(exported.contains("!User Dictionary Name: 可換環論"))
+    #expect(exported.contains("こーえんまこーれー\tCohen-Macaulay\t名詞\t深さが Krull 次元に等しいことを表す性質"))
+    #expect(exported.contains("せいそくれつ\t正則列\t名詞\t"))
+}
+
+@Test func decodeLegacySingleDictionaryValue() throws {
+    let legacy = """
+    {
+      "items": [
+        {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "word": "azooKey",
+          "reading": "あずーきー",
+          "hint": "アプリ"
+        }
+      ]
+    }
+    """
+
+    let value = try JSONDecoder().decode(Config.UserDictionary.Value.self, from: Data(legacy.utf8))
+
+    #expect(value.dictionaries.count == 1)
+    #expect(value.dictionaries[0].name == "ユーザ辞書")
+    #expect(value.dictionaries[0].isEnabled)
+    #expect(value.enabledItems.count == 1)
+}
+
+@Test func dynamicUserDictionaryFilteringKeepsConvertibleEntries() {
+    #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "コーエン"))
+    #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "コーエンマコーレー"))
+    #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "アカイコーエン"))
+    #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "アカイコーエンマコーレーデス"))
+    #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "カン", for: "アカン"))
+}
+
+@Test func dynamicUserDictionaryFilteringDropsUnrelatedEntries() {
+    #expect(!SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "セイソクレツ", for: "コーエン"))
+    #expect(!SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "", for: "コーエン"))
+    #expect(!SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエン", for: ""))
+}
+
+@Test func rebuildUserDictionaryIndexWritesSearchFiles() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("azookey-user-dictionary-index-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    try UserDictionaryIndexStore(directoryURL: directory).rebuild(entries: [
+        .init(word: "Cohen-Macaulay", ruby: "コーエンマコーレー", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5),
+        .init(word: "正則列", ruby: "セイソクレツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+    ])
+
+    #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user.louds").path))
+    #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user.loudschars2").path))
+    #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user0.loudstxt3").path))
+}

--- a/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTextFormatTests.swift
+++ b/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTextFormatTests.swift
@@ -58,6 +58,24 @@ import Testing
     #expect(value.enabledItems.count == 1)
 }
 
+@Test func decodeUTF16DictionaryWithoutLeavingBOM() throws {
+    let text = "よみ\t単語\t名詞\tコメント"
+    let littleEndianData = Data([0xFF, 0xFE]) + text.data(using: .utf16LittleEndian)!
+    let bigEndianData = Data([0xFE, 0xFF]) + text.data(using: .utf16BigEndian)!
+
+    let littleEndianResult = UserDictionaryTextCodec.importEntries(
+        from: try #require(UserDictionaryTextCodec.decodeText(from: littleEndianData)),
+        format: .googleJapaneseInput
+    )
+    let bigEndianResult = UserDictionaryTextCodec.importEntries(
+        from: try #require(UserDictionaryTextCodec.decodeText(from: bigEndianData)),
+        format: .googleJapaneseInput
+    )
+
+    #expect(littleEndianResult.entries.first?.reading == "よみ")
+    #expect(bigEndianResult.entries.first?.reading == "よみ")
+}
+
 @Test func dynamicUserDictionaryFilteringKeepsConvertibleEntries() {
     #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "コーエン"))
     #expect(SegmentsManager.shouldIncludeDynamicUserDictionaryEntry(ruby: "コーエンマコーレー", for: "コーエンマコーレー"))
@@ -79,12 +97,189 @@ import Testing
         try? FileManager.default.removeItem(at: directory)
     }
 
-    try UserDictionaryIndexStore(directoryURL: directory).rebuild(entries: [
-        .init(word: "Cohen-Macaulay", ruby: "コーエンマコーレー", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5),
-        .init(word: "正則列", ruby: "セイソクレツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
-    ])
+    _ = try UserDictionaryIndexStore(directoryURL: directory).rebuild(
+        entries: [
+            .init(word: "Cohen-Macaulay", ruby: "コーエンマコーレー", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5),
+            .init(word: "正則列", ruby: "セイソクレツ", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        ],
+        userRevision: 12,
+        systemRevision: 34
+    )
 
     #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user.louds").path))
     #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user.loudschars2").path))
     #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent("user0.loudstxt3").path))
+    #expect(UserDictionaryIndexStore(directoryURL: directory).metadata() == .init(
+        userRevision: 12,
+        systemRevision: 34,
+        indexedEntryCount: 2,
+        skippedEntryCount: 0
+    ))
+}
+
+@Test func userDictionaryIndexReportsSkippedUnsupportedReadings() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("azookey-user-dictionary-index-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    let result = try UserDictionaryIndexStore(directoryURL: directory).rebuild(
+        entries: [
+            .init(word: "unsupported", ruby: "\u{10FFFF}", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        ],
+        userRevision: 56,
+        systemRevision: 78
+    )
+
+    #expect(result.indexedEntryCount == 0)
+    #expect(result.skippedEntryCount == 1)
+    #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("user.louds").path))
+    #expect(UserDictionaryIndexStore(directoryURL: directory).metadata() == .init(
+        userRevision: 56,
+        systemRevision: 78,
+        indexedEntryCount: 0,
+        skippedEntryCount: 1
+    ))
+}
+
+@Test func userDictionaryIndexRequiresFilesWhenMetadataReportsIndexedEntries() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("azookey-user-dictionary-index-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    let store = UserDictionaryIndexStore(directoryURL: directory)
+    let metadata = UserDictionaryIndexStore.Metadata(
+        userRevision: 90,
+        systemRevision: 12,
+        indexedEntryCount: 1,
+        skippedEntryCount: 0
+    )
+
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let data = try JSONEncoder().encode(metadata)
+    try data.write(to: directory.appendingPathComponent("metadata.json", isDirectory: false))
+
+    #expect(!store.hasUsableIndex(for: metadata))
+
+    for fileName in ["user.louds", "user.loudschars2", "user0.loudstxt3"] {
+        try Data().write(to: directory.appendingPathComponent(fileName, isDirectory: false))
+    }
+
+    #expect(store.hasUsableIndex(for: metadata))
+}
+
+@Test func userDictionaryIndexStatusReportsReadyAndStaleCaches() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("azookey-user-dictionary-index-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    #expect(UserDictionaryIndexController.status(
+        directoryURL: directory,
+        currentUserRevision: 1,
+        currentSystemRevision: 2,
+        entryCount: 3
+    ) == .notBuilt(entryCount: 3))
+
+    _ = try UserDictionaryIndexStore(directoryURL: directory).rebuild(
+        entries: [
+            .init(word: "Cohen-Macaulay", ruby: "コーエンマコーレー", cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        ],
+        userRevision: 1,
+        systemRevision: 2
+    )
+
+    switch UserDictionaryIndexController.status(
+        directoryURL: directory,
+        currentUserRevision: 1,
+        currentSystemRevision: 2,
+        entryCount: 1
+    ) {
+    case .ready(let summary):
+        #expect(summary.indexedEntryCount == 1)
+        #expect(summary.skippedEntryCount == 0)
+    default:
+        Issue.record("Expected a ready user dictionary index")
+    }
+
+    switch UserDictionaryIndexController.status(
+        directoryURL: directory,
+        currentUserRevision: 2,
+        currentSystemRevision: 2,
+        entryCount: 4
+    ) {
+    case .needsRebuild(let currentEntryCount, let existing):
+        #expect(currentEntryCount == 4)
+        #expect(existing?.indexedEntryCount == 1)
+    default:
+        Issue.record("Expected a stale user dictionary index")
+    }
+}
+
+@Test func userDictionaryRevisionIgnoresDictionaryNameOnlyChanges() {
+    let defaults = UserDefaults.standard
+    let key = Config.UserDictionary.key
+    let revisionKey = Config.UserDictionary.revisionKey
+    let oldData = defaults.data(forKey: key)
+    let oldRevision = defaults.object(forKey: revisionKey)
+    defer {
+        if let oldData {
+            defaults.set(oldData, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        if let oldRevision {
+            defaults.set(oldRevision, forKey: revisionKey)
+        } else {
+            defaults.removeObject(forKey: revisionKey)
+        }
+    }
+
+    defaults.removeObject(forKey: key)
+    defaults.removeObject(forKey: revisionKey)
+
+    var value = Config.UserDictionary.default
+    value.dictionaries[0].name = "表示名だけ変更"
+    Config.UserDictionary().value = value
+    #expect(defaults.integer(forKey: revisionKey) == 0)
+
+    value.dictionaries[0].items[0].hint = "コメント変更"
+    Config.UserDictionary().value = value
+    #expect(defaults.integer(forKey: revisionKey) == 1)
+}
+
+@Test func systemUserDictionaryRevisionIgnoresLastUpdateOnlyChanges() {
+    let defaults = UserDefaults.standard
+    let key = Config.SystemUserDictionary.key
+    let revisionKey = Config.SystemUserDictionary.revisionKey
+    let oldData = defaults.data(forKey: key)
+    let oldRevision = defaults.object(forKey: revisionKey)
+    defer {
+        if let oldData {
+            defaults.set(oldData, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        if let oldRevision {
+            defaults.set(oldRevision, forKey: revisionKey)
+        } else {
+            defaults.removeObject(forKey: revisionKey)
+        }
+    }
+
+    defaults.removeObject(forKey: key)
+    defaults.removeObject(forKey: revisionKey)
+
+    var value = Config.SystemUserDictionary.default
+    value.lastUpdate = .now
+    Config.SystemUserDictionary().value = value
+    #expect(defaults.integer(forKey: revisionKey) == 0)
+
+    value.items.append(.init(word: "正則列", reading: "せいそくれつ"))
+    Config.SystemUserDictionary().value = value
+    #expect(defaults.integer(forKey: revisionKey) == 1)
 }

--- a/azooKeyMac/InputController/CandidateWindow/BaseCandidateViewController.swift
+++ b/azooKeyMac/InputController/CandidateWindow/BaseCandidateViewController.swift
@@ -9,6 +9,8 @@ class NonClickableTableView: NSTableView {
 }
 
 class CandidateTableCellView: NSTableCellView {
+    static let annotationMaxWidth: CGFloat = 170
+
     let candidateTextField: NSTextField
     let candidateAnnotationTextField: NSTextField
     private lazy var candidateTextFieldLeadingConstraint: NSLayoutConstraint = {
@@ -27,14 +29,20 @@ class CandidateTableCellView: NSTableCellView {
     private lazy var candidateAnnotationTextFieldTrailingConstraint: NSLayoutConstraint = {
         self.candidateAnnotationTextField.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     }()
+    private lazy var candidateAnnotationTextFieldWidthConstraint: NSLayoutConstraint = {
+        self.candidateAnnotationTextField.widthAnchor.constraint(lessThanOrEqualToConstant: Self.annotationMaxWidth)
+    }()
 
     override init(frame frameRect: NSRect) {
         self.candidateTextField = NSTextField(labelWithString: "")
         self.candidateTextField.font = NSFont.systemFont(ofSize: 18)
+        self.candidateTextField.lineBreakMode = .byTruncatingTail
         self.candidateAnnotationTextField = NSTextField(labelWithString: "")
-        self.candidateAnnotationTextField.font = NSFont.systemFont(ofSize: 12)
+        self.candidateAnnotationTextField.font = NSFont.systemFont(ofSize: 10)
         self.candidateAnnotationTextField.textColor = .systemGray
         self.candidateAnnotationTextField.alignment = .right
+        self.candidateAnnotationTextField.lineBreakMode = .byWordWrapping
+        self.candidateAnnotationTextField.maximumNumberOfLines = 2
         super.init(frame: frameRect)
         self.addSubview(self.candidateTextField)
         self.addSubview(self.candidateAnnotationTextField)
@@ -46,13 +54,14 @@ class CandidateTableCellView: NSTableCellView {
             self.candidateTextField.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
         self.candidateTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        self.candidateTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        self.candidateTextField.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         self.candidateAnnotationTextField.translatesAutoresizingMaskIntoConstraints = false
         self.candidateAnnotationTextField.setContentHuggingPriority(.required, for: .horizontal)
-        self.candidateAnnotationTextField.setContentCompressionResistancePriority(.required, for: .horizontal)
+        self.candidateAnnotationTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         NSLayoutConstraint.activate([
+            self.candidateAnnotationTextFieldWidthConstraint,
             self.candidateAnnotationTextField.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
 
@@ -66,6 +75,7 @@ class CandidateTableCellView: NSTableCellView {
         self.candidateAnnotationTextField.isBordered = false
         self.candidateAnnotationTextField.drawsBackground = false
         self.candidateAnnotationTextField.backgroundColor = .clear
+        self.candidateAnnotationTextField.cell?.wraps = true
 
         self.showCandidateAnnotationTextField(false)
     }
@@ -145,7 +155,7 @@ class BaseCandidateViewController: NSViewController {
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.tableView.selectionHighlightStyle = .regular
-        self.tableView.rowHeight = 32
+        self.tableView.rowHeight = 36
 
         self.view = containerView
     }

--- a/azooKeyMac/InputController/CandidateWindow/CandidateView.swift
+++ b/azooKeyMac/InputController/CandidateWindow/CandidateView.swift
@@ -96,10 +96,11 @@ class CandidatesViewController: BaseCandidateViewController {
 
     override func getWindowWidth(maxContentWidth: CGFloat) -> CGFloat {
         let hasAnnotation = self.candidates.contains { $0.displayContext.annotationText != nil }
+        let annotationWidth = hasAnnotation ? CandidateTableCellView.annotationMaxWidth + 12 : 0
         if self.showCandidateIndex {
-            return maxContentWidth + 48 + (hasAnnotation ? 56 : 0)
+            return maxContentWidth + 48 + annotationWidth
         } else {
-            return maxContentWidth + 20 + (hasAnnotation ? 56 : 0)
+            return maxContentWidth + 20 + annotationWidth
         }
     }
 }

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -40,6 +40,14 @@ struct ConfigWindow: View {
     @State private var debugTypoCorrectionDownloadInProgress = false
     @State private var debugTypoCorrectionErrorMessage: String?
 
+    private var userDictionaryValue: Config.UserDictionary.Value {
+        self.$userDictionary.wrappedValue
+    }
+
+    private var systemUserDictionaryValue: Config.SystemUserDictionary.Value {
+        self.$systemUserDictionary.wrappedValue
+    }
+
     private enum Tab: String, CaseIterable, Hashable {
         case basic = "基本"
         case customize = "カスタマイズ"
@@ -398,7 +406,7 @@ struct ConfigWindow: View {
             Section {
                 LabeledContent {
                     HStack {
-                        Text("\(self.userDictionary.value.items.count)件のアイテム")
+                        Text("\(self.userDictionaryValue.dictionaries.count)個の辞書 / \(self.userDictionaryValue.enabledItems.count)件の有効なアイテム")
                         Button("編集") {
                             (NSApplication.shared.delegate as? AppDelegate)!.openUserDictionaryEditorWindow()
                         }
@@ -410,32 +418,36 @@ struct ConfigWindow: View {
                     HStack {
                         switch self.systemUserDictionaryUpdateMessage {
                         case .none:
-                            if let updated = self.systemUserDictionary.value.lastUpdate {
+                            if let updated = self.systemUserDictionaryValue.lastUpdate {
                                 let date = updated.formatted(date: .omitted, time: .omitted)
-                                Text("最終更新: \(date) / \(self.systemUserDictionary.value.items.count)件のアイテム")
+                                Text("最終更新: \(date) / \(self.systemUserDictionaryValue.items.count)件のアイテム")
                             } else {
                                 Text("未設定")
                             }
                         case .error(let error):
                             Text("読み込みエラー: \(error.localizedDescription)")
                         case .successfulUpdate:
-                            Text("読み込みに成功しました / \(self.systemUserDictionary.value.items.count)件のアイテム")
+                            Text("読み込みに成功しました / \(self.systemUserDictionaryValue.items.count)件のアイテム")
                         }
                         Button("読み込む") {
                             do {
                                 let systemUserDictionaryEntries = try SystemUserDictionaryHelper.fetchEntries()
-                                self.systemUserDictionary.value.items = systemUserDictionaryEntries.map {
+                                var value = self.systemUserDictionaryValue
+                                value.items = systemUserDictionaryEntries.map {
                                     .init(word: $0.phrase, reading: $0.shortcut)
                                 }
-                                self.systemUserDictionary.value.lastUpdate = .now
+                                value.lastUpdate = .now
+                                self.$systemUserDictionary.wrappedValue = value
                                 self.systemUserDictionaryUpdateMessage = .successfulUpdate
                             } catch {
                                 self.systemUserDictionaryUpdateMessage = .error(error)
                             }
                         }
                         Button("リセット") {
-                            self.systemUserDictionary.value.lastUpdate = nil
-                            self.systemUserDictionary.value.items = []
+                            var value = self.systemUserDictionaryValue
+                            value.lastUpdate = nil
+                            value.items = []
+                            self.$systemUserDictionary.wrappedValue = value
                             self.systemUserDictionaryUpdateMessage = nil
                         }
                     }

--- a/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
+++ b/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
@@ -5,110 +5,242 @@
 //  Created by miwa on 2024/09/22.
 //
 
+import AppKit
 import Core
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct UserDictionaryEditorWindow: View {
 
     @ConfigState private var userDictionary = Config.UserDictionary()
 
+    @State private var selectedDictionaryID: UUID?
     @State private var editTargetID: UUID?
     @State private var undoItem: Config.UserDictionaryEntry?
+    @State private var deleteDictionaryTarget: Config.UserDictionaryGroup?
+    @State private var importFormat: UserDictionaryTextFormat = .automatic
+    @State private var alertMessage = ""
+    @State private var showingAlert = false
 
-    @ViewBuilder
-    private func helpButton(helpContent: LocalizedStringKey, isPresented: Binding<Bool>) -> some View {
-        if #available(macOS 14, *) {
-            Button("ヘルプ", systemImage: "questionmark") {
-                isPresented.wrappedValue = true
+    private var dictionaryValue: Config.UserDictionary.Value {
+        self.$userDictionary.wrappedValue
+    }
+
+    private var selectedDictionary: Config.UserDictionaryGroup? {
+        if let selectedDictionaryID,
+           let dictionary = dictionaryValue.dictionaries.first(where: { $0.id == selectedDictionaryID }) {
+            return dictionary
+        }
+        return dictionaryValue.dictionaries.first
+    }
+
+    private var selectedDictionaryIDForActions: UUID? {
+        selectedDictionary?.id
+    }
+
+    private var totalItemCount: Int {
+        dictionaryValue.dictionaries.reduce(0) { $0 + $1.items.count }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HStack(spacing: 0) {
+                sidebar
+                    .frame(width: 270)
+                Divider()
+                detailPane
             }
-            .labelStyle(.iconOnly)
-            .buttonBorderShape(.circle)
-            .popover(isPresented: isPresented) {
-                Text(helpContent).padding()
+        }
+        .font(.system(.body, design: .default))
+        .background(Color(nsColor: .windowBackgroundColor))
+        .frame(minHeight: 520, maxHeight: 760)
+        .frame(minWidth: 900, maxWidth: 1_080)
+        .onAppear {
+            ensureSelection()
+        }
+        .alert("ユーザ辞書", isPresented: $showingAlert) {
+            Button("OK") {}
+        } message: {
+            Text(alertMessage)
+        }
+        .alert(
+            "辞書を削除しますか？",
+            isPresented: Binding(
+                get: { deleteDictionaryTarget != nil },
+                set: {
+                    if !$0 {
+                        deleteDictionaryTarget = nil
+                    }
+                }
+            )
+        ) {
+            Button("削除", role: .destructive) {
+                deleteTargetDictionary()
+            }
+            Button("キャンセル", role: .cancel) {
+                deleteDictionaryTarget = nil
+            }
+        } message: {
+            if let deleteDictionaryTarget {
+                Text("「\(deleteDictionaryTarget.name)」と、その中の\(deleteDictionaryTarget.items.count)件の単語を削除します。この操作は取り消せません。")
             }
         }
     }
 
-    private var isAdditionDisabled: Bool {
-        self.userDictionary.value.items.count >= 50
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("ユーザ辞書")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text("\(dictionaryValue.dictionaries.count)個の辞書 / \(totalItemCount)件の単語")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.primary)
+                }
+                Spacer()
+                Button("新規辞書", systemImage: "plus") {
+                    addDictionary()
+                }
+                .keyboardShortcut("n", modifiers: [.command])
+            }
+
+            HStack(spacing: 10) {
+                Picker("読み込み形式", selection: $importFormat) {
+                    ForEach(UserDictionaryTextFormat.allCases) { format in
+                        Text(format.localizedName).tag(format)
+                    }
+                }
+                .frame(width: 260)
+
+                Button("新規辞書として読み込む", systemImage: "folder.badge.plus") {
+                    importFromFile(intoDictionaryID: nil)
+                }
+
+                Button("選択辞書に追加", systemImage: "square.and.arrow.down") {
+                    importFromFile(intoDictionaryID: selectedDictionaryIDForActions)
+                }
+                .disabled(selectedDictionaryIDForActions == nil)
+
+                Spacer()
+
+                Button("選択辞書を書き出す", systemImage: "square.and.arrow.up") {
+                    exportSelectedDictionary()
+                }
+                .disabled(selectedDictionary == nil)
+            }
+        }
+        .padding(18)
     }
 
-    var body: some View {
-        VStack {
-            Text("ユーザ辞書の設定")
-                .bold()
-                .font(.title)
-            Text("この機能はβ版です。予告なく仕様を変更することがあるほか、最大50件に限定しています。")
-                .font(.caption)
-            Spacer()
-            if let editTargetID {
-                let itemBinding = Binding(
-                    get: {
-                        self.userDictionary.value.items.first {
-                            $0.id == editTargetID
-                        } ?? .init(word: "", reading: "")
-                    },
-                    set: {
-                        if let index = self.userDictionary.value.items.firstIndex(where: {
-                            $0.id == editTargetID
-                        }) {
-                            self.userDictionary.value.items[index] = $0
-                        }
-                    }
-                )
-                Form {
-                    TextField("単語", text: itemBinding.word)
-                    TextField("読み", text: itemBinding.reading)
-                    TextField("ヒント", text: itemBinding.nonNullHint)
-                    HStack {
-                        Spacer()
-                        Button("完了", systemImage: "checkmark") {
-                            self.editTargetID = nil
-                        }
-                        Spacer()
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("辞書一覧")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 14)
+                .padding(.top, 14)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(dictionaryValue.dictionaries) { dictionary in
+                        dictionaryRow(dictionary)
                     }
                 }
-            } else {
-                HStack {
-                    Spacer()
-                    Button("追加", systemImage: "plus") {
-                        let newItem = Config.UserDictionaryEntry(word: "", reading: "", hint: nil)
-                        self.userDictionary.value.items.append(newItem)
-                        self.editTargetID = newItem.id
-                        self.undoItem = nil
-                    }
-                    .disabled(self.isAdditionDisabled)
-                    if self.isAdditionDisabled {
-                        Label("50件を超えています", systemImage: "exclamationmark.octagon")
-                            .foregroundStyle(.red)
-                    }
-                    if let undoItem {
-                        Button("元に戻す", systemImage: "arrow.uturn.backward") {
-                            self.userDictionary.value.items.append(undoItem)
-                            self.undoItem = nil
-                        }
-                    }
-                    Spacer()
-                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
             }
-            HStack {
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Button("追加", systemImage: "plus") {
+                    addDictionary()
+                }
+                Button("削除", systemImage: "trash", role: .destructive) {
+                    if let selectedDictionary {
+                        deleteDictionaryTarget = selectedDictionary
+                    }
+                }
+                .disabled(selectedDictionary == nil)
                 Spacer()
-                Table(self.userDictionary.value.items) {
+            }
+            .padding(12)
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func dictionaryRow(_ dictionary: Config.UserDictionaryGroup) -> some View {
+        let isSelected = selectedDictionary?.id == dictionary.id
+        return HStack(spacing: 10) {
+            Button(dictionary.isEnabled ? "無効にする" : "有効にする", systemImage: dictionary.isEnabled ? "checkmark.circle.fill" : "circle") {
+                setDictionaryEnabled(dictionary.id, isEnabled: !dictionary.isEnabled)
+            }
+            .buttonStyle(.plain)
+            .labelStyle(.iconOnly)
+            .foregroundStyle(dictionary.isEnabled ? Color.accentColor : Color(nsColor: .secondaryLabelColor))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(dictionary.name.isEmpty ? "名称未設定" : dictionary.name)
+                    .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text("\(dictionary.items.count)件")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .contentShape(RoundedRectangle(cornerRadius: 7))
+        .background {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(isSelected ? Color.accentColor.opacity(0.14) : Color.clear)
+        }
+        .onTapGesture {
+            selectedDictionaryID = dictionary.id
+            editTargetID = nil
+            undoItem = nil
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if let selectedDictionary {
+            VStack(alignment: .leading, spacing: 14) {
+                dictionarySummary(selectedDictionary)
+
+                if let editTargetID {
+                    editEntryForm(editTargetID: editTargetID, dictionaryID: selectedDictionary.id)
+                } else {
+                    HStack {
+                        Button("単語を追加", systemImage: "plus") {
+                            addEntry(to: selectedDictionary.id)
+                        }
+                        if let undoItem {
+                            Button("元に戻す", systemImage: "arrow.uturn.backward") {
+                                restoreEntry(undoItem, to: selectedDictionary.id)
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+
+                Table(selectedDictionary.items) {
                     TableColumn("") { item in
-                        HStack {
+                        HStack(spacing: 6) {
                             Button("編集する", systemImage: "pencil") {
-                                self.editTargetID = item.id
-                                self.undoItem = nil
+                                editTargetID = item.id
+                                undoItem = nil
                             }
                             .buttonStyle(.bordered)
                             .labelStyle(.iconOnly)
+
                             Button("削除する", systemImage: "trash", role: .destructive) {
-                                if let itemIndex = self.userDictionary.value.items.firstIndex(where: {
-                                    $0.id == item.id
-                                }) {
-                                    self.undoItem = self.userDictionary.value.items[itemIndex]
-                                    self.userDictionary.value.items.remove(at: itemIndex)
-                                }
+                                removeEntry(item, from: selectedDictionary.id)
                             }
                             .buttonStyle(.bordered)
                             .labelStyle(.iconOnly)
@@ -116,15 +248,290 @@ struct UserDictionaryEditorWindow: View {
                     }
                     TableColumn("単語", value: \.word)
                     TableColumn("読み", value: \.reading)
-                    TableColumn("ヒント", value: \.nonNullHint)
+                    TableColumn("コメント", value: \.nonNullHint)
                 }
-                .disabled(editTargetID != nil)
-                Spacer()
             }
-            Spacer()
+            .padding(18)
+        } else {
+            VStack(spacing: 12) {
+                Text("辞書がありません")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Button("新規辞書を作成", systemImage: "plus") {
+                    addDictionary()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(minHeight: 300, maxHeight: 600)
-        .frame(minWidth: 600, maxWidth: 800)
+    }
+
+    private func dictionarySummary(_ dictionary: Config.UserDictionaryGroup) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                TextField("辞書名", text: dictionaryNameBinding(for: dictionary.id))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 16, weight: .medium))
+                    .frame(minWidth: 240)
+
+                Toggle("有効", isOn: dictionaryEnabledBinding(for: dictionary.id))
+                    .toggleStyle(.checkbox)
+
+                Spacer()
+
+                Text("\(dictionary.items.count)件")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
+            }
+
+            Text("この辞書内の単語だけを編集します。読み込みと書き出しは画面上部の操作から実行します。")
+                .font(.system(size: 12))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+        }
+    }
+
+    private func editEntryForm(editTargetID: UUID, dictionaryID: UUID) -> some View {
+        let itemBinding = entryBinding(editTargetID: editTargetID, dictionaryID: dictionaryID)
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("単語を編集")
+                .font(.system(size: 14, weight: .semibold))
+            HStack(spacing: 10) {
+                TextField("単語", text: itemBinding.word)
+                TextField("読み", text: itemBinding.reading)
+                TextField("コメント", text: itemBinding.nonNullHint)
+                Button("完了", systemImage: "checkmark") {
+                    self.editTargetID = nil
+                }
+            }
+        }
+        .padding(12)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        }
+    }
+
+    private func dictionaryNameBinding(for dictionaryID: UUID) -> Binding<String> {
+        Binding {
+            dictionaryValue.dictionaries.first { $0.id == dictionaryID }?.name ?? ""
+        } set: { newValue in
+            updateUserDictionary { value in
+                guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
+                    return
+                }
+                value.dictionaries[index].name = newValue
+            }
+        }
+    }
+
+    private func dictionaryEnabledBinding(for dictionaryID: UUID) -> Binding<Bool> {
+        Binding {
+            dictionaryValue.dictionaries.first { $0.id == dictionaryID }?.isEnabled ?? false
+        } set: { isEnabled in
+            setDictionaryEnabled(dictionaryID, isEnabled: isEnabled)
+        }
+    }
+
+    private func entryBinding(editTargetID: UUID, dictionaryID: UUID) -> Binding<Config.UserDictionaryEntry> {
+        Binding {
+            dictionaryValue.dictionaries
+                .first { $0.id == dictionaryID }?
+                .items
+                .first { $0.id == editTargetID } ?? .init(word: "", reading: "")
+        } set: { newValue in
+            updateUserDictionary { value in
+                guard let dictionaryIndex = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }),
+                      let itemIndex = value.dictionaries[dictionaryIndex].items.firstIndex(where: { $0.id == editTargetID }) else {
+                    return
+                }
+                value.dictionaries[dictionaryIndex].items[itemIndex] = newValue
+            }
+        }
+    }
+
+    private func updateUserDictionary(_ update: (inout Config.UserDictionary.Value) -> Void) {
+        var value = dictionaryValue
+        update(&value)
+        self.$userDictionary.wrappedValue = value
+    }
+
+    private func ensureSelection() {
+        if selectedDictionaryID == nil || selectedDictionary == nil {
+            selectedDictionaryID = dictionaryValue.dictionaries.first?.id
+        }
+    }
+
+    private func addDictionary() {
+        let dictionary = Config.UserDictionaryGroup(name: nextDictionaryName())
+        updateUserDictionary {
+            $0.dictionaries.append(dictionary)
+        }
+        selectedDictionaryID = dictionary.id
+        editTargetID = nil
+        undoItem = nil
+    }
+
+    private func nextDictionaryName() -> String {
+        let baseName = "新しい辞書"
+        let existingNames = Set(dictionaryValue.dictionaries.map(\.name))
+        guard existingNames.contains(baseName) else {
+            return baseName
+        }
+        var number = 2
+        while existingNames.contains("\(baseName) \(number)") {
+            number += 1
+        }
+        return "\(baseName) \(number)"
+    }
+
+    private func setDictionaryEnabled(_ dictionaryID: UUID, isEnabled: Bool) {
+        updateUserDictionary { value in
+            guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
+                return
+            }
+            value.dictionaries[index].isEnabled = isEnabled
+        }
+    }
+
+    private func deleteTargetDictionary() {
+        guard let target = deleteDictionaryTarget else {
+            return
+        }
+        updateUserDictionary {
+            $0.dictionaries.removeAll { $0.id == target.id }
+        }
+        deleteDictionaryTarget = nil
+        selectedDictionaryID = dictionaryValue.dictionaries.first?.id
+        editTargetID = nil
+        undoItem = nil
+    }
+
+    private func addEntry(to dictionaryID: UUID) {
+        let newItem = Config.UserDictionaryEntry(word: "", reading: "", hint: nil)
+        updateUserDictionary { value in
+            guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
+                return
+            }
+            value.dictionaries[index].items.append(newItem)
+        }
+        editTargetID = newItem.id
+        undoItem = nil
+    }
+
+    private func restoreEntry(_ item: Config.UserDictionaryEntry, to dictionaryID: UUID) {
+        updateUserDictionary { value in
+            guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
+                return
+            }
+            value.dictionaries[index].items.append(item)
+        }
+        undoItem = nil
+    }
+
+    private func removeEntry(_ item: Config.UserDictionaryEntry, from dictionaryID: UUID) {
+        updateUserDictionary { value in
+            guard let dictionaryIndex = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }),
+                  let itemIndex = value.dictionaries[dictionaryIndex].items.firstIndex(where: { $0.id == item.id }) else {
+                return
+            }
+            undoItem = value.dictionaries[dictionaryIndex].items[itemIndex]
+            value.dictionaries[dictionaryIndex].items.remove(at: itemIndex)
+        }
+    }
+
+    private func importFromFile(intoDictionaryID dictionaryID: UUID?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.plainText, .commaSeparatedText, .text]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.title = "ユーザ辞書ファイルを選択"
+
+        let handler: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else {
+                return
+            }
+            do {
+                let data = try Data(contentsOf: url)
+                guard let text = UserDictionaryTextCodec.decodeText(from: data) else {
+                    showAlert("ファイルの文字コードを判定できませんでした。")
+                    return
+                }
+                let result = UserDictionaryTextCodec.importEntries(from: text, format: importFormat)
+                guard !result.entries.isEmpty else {
+                    showAlert("有効な単語が見つかりませんでした。")
+                    return
+                }
+                if let dictionaryID {
+                    updateUserDictionary { value in
+                        guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
+                            return
+                        }
+                        value.dictionaries[index].items.append(contentsOf: result.entries)
+                    }
+                    selectedDictionaryID = dictionaryID
+                } else {
+                    let fallbackName = url.deletingPathExtension().lastPathComponent
+                    let dictionary = Config.UserDictionaryGroup(
+                        name: result.dictionaryName ?? fallbackName,
+                        isEnabled: true,
+                        items: result.entries
+                    )
+                    updateUserDictionary {
+                        $0.dictionaries.append(dictionary)
+                    }
+                    selectedDictionaryID = dictionary.id
+                }
+                editTargetID = nil
+                undoItem = nil
+                let skipped = result.skippedLineCount == 0 ? "" : " / \(result.skippedLineCount)行をスキップしました"
+                showAlert("\(result.entries.count)件を読み込みました\(skipped)。")
+            } catch {
+                showAlert("読み込みに失敗しました: \(error.localizedDescription)")
+            }
+        }
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            panel.beginSheetModal(for: window, completionHandler: handler)
+        } else {
+            panel.begin(completionHandler: handler)
+        }
+    }
+
+    private func exportSelectedDictionary() {
+        guard let selectedDictionary else {
+            return
+        }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = "\(selectedDictionary.name).txt"
+        panel.title = "ユーザ辞書を書き出し"
+
+        let handler: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else {
+                return
+            }
+            do {
+                let exported = UserDictionaryTextCodec.exportEntries(
+                    selectedDictionary.items,
+                    dictionaryName: selectedDictionary.name
+                )
+                try Data(exported.utf8).write(to: url)
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            } catch {
+                showAlert("書き出しに失敗しました: \(error.localizedDescription)")
+            }
+        }
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            panel.beginSheetModal(for: window, completionHandler: handler)
+        } else {
+            panel.begin(completionHandler: handler)
+        }
+    }
+
+    private func showAlert(_ message: String) {
+        alertMessage = message
+        showingAlert = true
     }
 }
 

--- a/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
+++ b/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
@@ -21,6 +21,15 @@ struct UserDictionaryEditorWindow: View {
     @State private var importFormat: UserDictionaryTextFormat = .automatic
     @State private var alertMessage = ""
     @State private var showingAlert = false
+    @State private var indexStatus: UserDictionaryIndexStatus = .notBuilt(entryCount: 0)
+    @State private var indexBuildInProgress = false
+    @State private var indexBuildMessage: String?
+    @State private var indexBuildErrorMessage: String?
+    @State private var scheduledIndexBuildTask: Task<Void, Never>?
+    @State private var activeExportPanel: NSOpenPanel?
+    @State private var presentingWindow: NSWindow?
+    @State private var entrySearchText = ""
+    @State private var entrySortOrder: [KeyPathComparator<Config.UserDictionaryEntry>] = []
 
     private var dictionaryValue: Config.UserDictionary.Value {
         self.$userDictionary.wrappedValue
@@ -42,6 +51,26 @@ struct UserDictionaryEditorWindow: View {
         dictionaryValue.dictionaries.reduce(0) { $0 + $1.items.count }
     }
 
+    private var actionControlHeight: CGFloat {
+        30
+    }
+
+    private var azooKeyMemoryDirectoryURL: URL {
+        if #available(macOS 13, *) {
+            URL.applicationSupportDirectory
+                .appending(path: "azooKey", directoryHint: .isDirectory)
+                .appending(path: "memory", directoryHint: .isDirectory)
+        } else {
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                .appendingPathComponent("azooKey", isDirectory: true)
+                .appendingPathComponent("memory", isDirectory: true)
+        }
+    }
+
+    private var presentationWindow: NSWindow? {
+        presentingWindow ?? NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible })
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -55,10 +84,15 @@ struct UserDictionaryEditorWindow: View {
         }
         .font(.system(.body, design: .default))
         .background(Color(nsColor: .windowBackgroundColor))
+        .background(WindowAccessor(window: $presentingWindow))
         .frame(minHeight: 520, maxHeight: 760)
         .frame(minWidth: 900, maxWidth: 1_080)
         .onAppear {
             ensureSelection()
+            refreshIndexStatus()
+        }
+        .onDisappear {
+            scheduledIndexBuildTask?.cancel()
         }
         .alert("ユーザ辞書", isPresented: $showingAlert) {
             Button("OK") {}
@@ -94,45 +128,93 @@ struct UserDictionaryEditorWindow: View {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("ユーザ辞書")
-                        .font(.system(size: 22, weight: .semibold))
+                        .font(.system(size: 18, weight: .semibold))
                         .foregroundStyle(.primary)
                     Text("\(dictionaryValue.dictionaries.count)個の辞書 / \(totalItemCount)件の単語")
                         .font(.system(size: 13))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                 }
                 Spacer()
-                Button("新規辞書", systemImage: "plus") {
-                    addDictionary()
-                }
-                .keyboardShortcut("n", modifiers: [.command])
             }
 
-            HStack(spacing: 10) {
-                Picker("読み込み形式", selection: $importFormat) {
-                    ForEach(UserDictionaryTextFormat.allCases) { format in
-                        Text(format.localizedName).tag(format)
-                    }
-                }
-                .frame(width: 260)
-
-                Button("新規辞書として読み込む", systemImage: "folder.badge.plus") {
-                    importFromFile(intoDictionaryID: nil)
-                }
-
-                Button("選択辞書に追加", systemImage: "square.and.arrow.down") {
-                    importFromFile(intoDictionaryID: selectedDictionaryIDForActions)
-                }
-                .disabled(selectedDictionaryIDForActions == nil)
-
-                Spacer()
-
-                Button("選択辞書を書き出す", systemImage: "square.and.arrow.up") {
-                    exportSelectedDictionary()
-                }
-                .disabled(selectedDictionary == nil)
-            }
+            indexStatusBar
+            importExportBar
         }
         .padding(18)
+    }
+
+    private var indexStatusBar: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Label(indexStatusTitle, systemImage: indexStatusSystemImage)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(indexStatusColor)
+                if indexBuildInProgress {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                }
+                Text(indexStatusDetailText)
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .lineLimit(1)
+                Spacer()
+                ToolbarActionButton(title: "状態更新", systemImage: "arrow.clockwise", height: actionControlHeight, isEnabled: !indexBuildInProgress) { _ in
+                    refreshIndexStatus()
+                }
+                ToolbarActionButton(
+                    title: indexBuildErrorMessage == nil ? "今すぐ再作成" : "再実行",
+                    systemImage: "arrow.triangle.2.circlepath",
+                    height: actionControlHeight,
+                    isEnabled: !indexBuildInProgress
+                ) { _ in
+                    rebuildIndexNow()
+                }
+            }
+            Text(indexStatusMessageText)
+                .font(.system(size: 12))
+                .foregroundStyle(indexStatusMessageColor)
+                .lineLimit(1)
+                .frame(height: 16, alignment: .topLeading)
+                .opacity(indexStatusMessageText.isEmpty ? 0 : 1)
+        }
+    }
+
+    private var importExportBar: some View {
+        HStack(spacing: 10) {
+            Picker("形式", selection: $importFormat) {
+                ForEach(UserDictionaryTextFormat.allCases) { format in
+                    Text(format.localizedName).tag(format)
+                }
+            }
+            .frame(width: 260)
+            .frame(height: actionControlHeight)
+            .controlSize(.regular)
+
+            ToolbarActionButton(title: "新規辞書として読み込む", systemImage: "folder.badge.plus", height: actionControlHeight) { window in
+                importFromFile(intoDictionaryID: nil, presentingWindow: window)
+            }
+
+            ToolbarActionButton(
+                title: "選択辞書に追加",
+                systemImage: "square.and.arrow.down",
+                height: actionControlHeight,
+                isEnabled: selectedDictionaryIDForActions != nil
+            ) { window in
+                importFromFile(intoDictionaryID: selectedDictionaryIDForActions, presentingWindow: window)
+            }
+
+            ToolbarActionButton(
+                title: "選択辞書を書き出す",
+                systemImage: "square.and.arrow.up",
+                height: actionControlHeight,
+                isEnabled: selectedDictionary != nil
+            ) { window in
+                exportSelectedDictionary(presentingWindow: window)
+            }
+
+            Spacer()
+        }
     }
 
     private var sidebar: some View {
@@ -155,17 +237,18 @@ struct UserDictionaryEditorWindow: View {
 
             Divider()
 
-            HStack(spacing: 8) {
-                Button("追加", systemImage: "plus") {
-                    addDictionary()
-                }
-                Button("削除", systemImage: "trash", role: .destructive) {
-                    if let selectedDictionary {
-                        deleteDictionaryTarget = selectedDictionary
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    ToolbarActionButton(title: "追加", systemImage: "plus", height: actionControlHeight) { _ in
+                        addDictionary()
                     }
+                    ToolbarActionButton(title: "削除", systemImage: "trash", height: actionControlHeight, isEnabled: selectedDictionary != nil) { _ in
+                        if let selectedDictionary {
+                            deleteDictionaryTarget = selectedDictionary
+                        }
+                    }
+                    Spacer()
                 }
-                .disabled(selectedDictionary == nil)
-                Spacer()
             }
             .padding(12)
         }
@@ -204,6 +287,7 @@ struct UserDictionaryEditorWindow: View {
             selectedDictionaryID = dictionary.id
             editTargetID = nil
             undoItem = nil
+            entrySearchText = ""
         }
     }
 
@@ -216,20 +300,24 @@ struct UserDictionaryEditorWindow: View {
                 if let editTargetID {
                     editEntryForm(editTargetID: editTargetID, dictionaryID: selectedDictionary.id)
                 } else {
-                    HStack {
+                    HStack(spacing: 10) {
                         Button("単語を追加", systemImage: "plus") {
                             addEntry(to: selectedDictionary.id)
                         }
+                        .frame(height: actionControlHeight)
                         if let undoItem {
                             Button("元に戻す", systemImage: "arrow.uturn.backward") {
                                 restoreEntry(undoItem, to: selectedDictionary.id)
                             }
+                            .frame(height: actionControlHeight)
                         }
                         Spacer()
+                        entrySearchField
                     }
+                    .controlSize(.regular)
                 }
 
-                Table(selectedDictionary.items) {
+                Table(displayedItems(for: selectedDictionary), sortOrder: $entrySortOrder) {
                     TableColumn("") { item in
                         HStack(spacing: 6) {
                             Button("編集する", systemImage: "pencil") {
@@ -238,17 +326,22 @@ struct UserDictionaryEditorWindow: View {
                             }
                             .buttonStyle(.bordered)
                             .labelStyle(.iconOnly)
+                            .frame(height: actionControlHeight)
 
                             Button("削除する", systemImage: "trash", role: .destructive) {
                                 removeEntry(item, from: selectedDictionary.id)
                             }
                             .buttonStyle(.bordered)
                             .labelStyle(.iconOnly)
+                            .frame(height: actionControlHeight)
                         }
                     }
                     TableColumn("単語", value: \.word)
                     TableColumn("読み", value: \.reading)
-                    TableColumn("コメント", value: \.nonNullHint)
+                    TableColumn("コメント") { item in
+                        Text(item.nonNullHint)
+                            .lineLimit(1)
+                    }
                 }
             }
             .padding(18)
@@ -262,6 +355,53 @@ struct UserDictionaryEditorWindow: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var entrySearchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            TextField("単語・読み・コメントを検索", text: $entrySearchText)
+                .textFieldStyle(.plain)
+            if !entrySearchText.isEmpty {
+                Button("検索を消去", systemImage: "xmark.circle.fill") {
+                    entrySearchText = ""
+                }
+                .buttonStyle(.plain)
+                .labelStyle(.iconOnly)
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            }
+        }
+        .padding(.horizontal, 9)
+        .frame(width: 260, height: actionControlHeight)
+        .background {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(nsColor: .textBackgroundColor))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func displayedItems(for dictionary: Config.UserDictionaryGroup) -> [Config.UserDictionaryEntry] {
+        let filteredItems = filteredItems(for: dictionary.items)
+        guard !entrySortOrder.isEmpty else {
+            return filteredItems
+        }
+        return filteredItems.sorted(using: entrySortOrder)
+    }
+
+    private func filteredItems(for items: [Config.UserDictionaryEntry]) -> [Config.UserDictionaryEntry] {
+        let query = entrySearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return items
+        }
+        return items.filter { item in
+            item.word.localizedStandardContains(query)
+                || item.reading.localizedStandardContains(query)
+                || item.nonNullHint.localizedStandardContains(query)
         }
     }
 
@@ -283,7 +423,7 @@ struct UserDictionaryEditorWindow: View {
                     .foregroundStyle(.primary)
             }
 
-            Text("この辞書内の単語だけを編集します。読み込みと書き出しは画面上部の操作から実行します。")
+            Text("この辞書内の単語だけを編集します。読み込みと書き出しはヘッダーの操作から実行します。")
                 .font(.system(size: 12))
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
         }
@@ -301,7 +441,9 @@ struct UserDictionaryEditorWindow: View {
                 Button("完了", systemImage: "checkmark") {
                     self.editTargetID = nil
                 }
+                .frame(height: actionControlHeight)
             }
+            .controlSize(.regular)
         }
         .padding(12)
         .background {
@@ -314,7 +456,7 @@ struct UserDictionaryEditorWindow: View {
         Binding {
             dictionaryValue.dictionaries.first { $0.id == dictionaryID }?.name ?? ""
         } set: { newValue in
-            updateUserDictionary { value in
+            updateUserDictionary(scheduleIndexRebuild: false, refreshIndexStatusWhenSkipped: false) { value in
                 guard let index = value.dictionaries.firstIndex(where: { $0.id == dictionaryID }) else {
                     return
                 }
@@ -348,10 +490,19 @@ struct UserDictionaryEditorWindow: View {
         }
     }
 
-    private func updateUserDictionary(_ update: (inout Config.UserDictionary.Value) -> Void) {
+    private func updateUserDictionary(
+        scheduleIndexRebuild: Bool = true,
+        refreshIndexStatusWhenSkipped: Bool = true,
+        _ update: (inout Config.UserDictionary.Value) -> Void
+    ) {
         var value = dictionaryValue
         update(&value)
         self.$userDictionary.wrappedValue = value
+        if scheduleIndexRebuild {
+            scheduleIndexRebuildSoon()
+        } else if refreshIndexStatusWhenSkipped {
+            refreshIndexStatus()
+        }
     }
 
     private func ensureSelection() {
@@ -362,12 +513,13 @@ struct UserDictionaryEditorWindow: View {
 
     private func addDictionary() {
         let dictionary = Config.UserDictionaryGroup(name: nextDictionaryName())
-        updateUserDictionary {
+        updateUserDictionary(scheduleIndexRebuild: false, refreshIndexStatusWhenSkipped: false) {
             $0.dictionaries.append(dictionary)
         }
         selectedDictionaryID = dictionary.id
         editTargetID = nil
         undoItem = nil
+        entrySearchText = ""
     }
 
     private func nextDictionaryName() -> String {
@@ -403,6 +555,7 @@ struct UserDictionaryEditorWindow: View {
         selectedDictionaryID = dictionaryValue.dictionaries.first?.id
         editTargetID = nil
         undoItem = nil
+        entrySearchText = ""
     }
 
     private func addEntry(to dictionaryID: UUID) {
@@ -415,6 +568,7 @@ struct UserDictionaryEditorWindow: View {
         }
         editTargetID = newItem.id
         undoItem = nil
+        entrySearchText = ""
     }
 
     private func restoreEntry(_ item: Config.UserDictionaryEntry, to dictionaryID: UUID) {
@@ -438,9 +592,8 @@ struct UserDictionaryEditorWindow: View {
         }
     }
 
-    private func importFromFile(intoDictionaryID dictionaryID: UUID?) {
+    private func importFromFile(intoDictionaryID dictionaryID: UUID?, presentingWindow: NSWindow? = nil) {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.plainText, .commaSeparatedText, .text]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
@@ -483,6 +636,7 @@ struct UserDictionaryEditorWindow: View {
                 }
                 editTargetID = nil
                 undoItem = nil
+                entrySearchText = ""
                 let skipped = result.skippedLineCount == 0 ? "" : " / \(result.skippedLineCount)行をスキップしました"
                 showAlert("\(result.entries.count)件を読み込みました\(skipped)。")
             } catch {
@@ -490,48 +644,317 @@ struct UserDictionaryEditorWindow: View {
             }
         }
 
-        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+        if let window = presentingWindow ?? presentationWindow {
+            window.makeKeyAndOrderFront(nil)
             panel.beginSheetModal(for: window, completionHandler: handler)
         } else {
             panel.begin(completionHandler: handler)
         }
     }
 
-    private func exportSelectedDictionary() {
+    private func exportSelectedDictionary(presentingWindow: NSWindow? = nil) {
         guard let selectedDictionary else {
+            showAlert("書き出す辞書を選択してください。")
             return
         }
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.plainText]
-        panel.nameFieldStringValue = "\(selectedDictionary.name).txt"
-        panel.title = "ユーザ辞書を書き出し"
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        let dictionaryName = selectedDictionary.name.isEmpty ? "ユーザ辞書" : selectedDictionary.name
+        let items = selectedDictionary.items
+        let fileNameField = exportFileNameField(defaultFileName: "\(dictionaryName).txt")
+        panel.accessoryView = fileNameField.container
+        panel.title = "ユーザ辞書の書き出し先を選択"
+        panel.message = "書き出し先のフォルダを選び、ファイル名を指定してください。"
+        panel.prompt = "書き出す"
 
+        activeExportPanel = panel
         let handler: (NSApplication.ModalResponse) -> Void = { response in
-            guard response == .OK, let url = panel.url else {
+            activeExportPanel = nil
+            guard response == .OK, let directoryURL = panel.url else {
                 return
             }
+            let destinationURL = directoryURL.appendingPathComponent(normalizedExportFileName(fileNameField.textField.stringValue))
             do {
+                let canAccessDirectory = directoryURL.startAccessingSecurityScopedResource()
+                defer {
+                    if canAccessDirectory {
+                        directoryURL.stopAccessingSecurityScopedResource()
+                    }
+                }
                 let exported = UserDictionaryTextCodec.exportEntries(
-                    selectedDictionary.items,
-                    dictionaryName: selectedDictionary.name
+                    items,
+                    dictionaryName: dictionaryName
                 )
-                try Data(exported.utf8).write(to: url)
-                NSWorkspace.shared.activateFileViewerSelecting([url])
+                try Data(exported.utf8).write(to: destinationURL)
+                indexBuildMessage = "「\(destinationURL.lastPathComponent)」を書き出しました。"
             } catch {
                 showAlert("書き出しに失敗しました: \(error.localizedDescription)")
             }
         }
 
-        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = presentingWindow ?? presentationWindow {
+            window.makeKeyAndOrderFront(nil)
             panel.beginSheetModal(for: window, completionHandler: handler)
         } else {
             panel.begin(completionHandler: handler)
         }
     }
 
+    private func exportFileNameField(defaultFileName: String) -> (container: NSView, textField: NSTextField) {
+        let label = NSTextField(labelWithString: "ファイル名:")
+        let textField = NSTextField(string: defaultFileName)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 32))
+        container.addSubview(label)
+        container.addSubview(textField)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            textField.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 8),
+            textField.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            textField.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            textField.widthAnchor.constraint(greaterThanOrEqualToConstant: 240)
+        ])
+        return (container, textField)
+    }
+
+    private func normalizedExportFileName(_ rawFileName: String) -> String {
+        let trimmed = rawFileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = "ユーザ辞書.txt"
+        let fileName = trimmed.isEmpty ? fallback : trimmed
+        return fileName.lowercased().hasSuffix(".txt") ? fileName : "\(fileName).txt"
+    }
+
+    private var indexStatusTitle: String {
+        if indexBuildInProgress {
+            return "キャッシュ作成中"
+        }
+        if indexBuildErrorMessage != nil {
+            return "キャッシュ作成失敗"
+        }
+        switch indexStatus {
+        case .notBuilt:
+            return "キャッシュ未作成"
+        case .ready:
+            return "キャッシュ最新"
+        case .needsRebuild:
+            return "キャッシュ更新が必要"
+        }
+    }
+
+    private var indexStatusSystemImage: String {
+        if indexBuildInProgress {
+            return "clock.arrow.circlepath"
+        }
+        if indexBuildErrorMessage != nil {
+            return "exclamationmark.triangle"
+        }
+        switch indexStatus {
+        case .notBuilt:
+            return "tray"
+        case .ready:
+            return "checkmark.circle"
+        case .needsRebuild:
+            return "arrow.triangle.2.circlepath"
+        }
+    }
+
+    private var indexStatusColor: Color {
+        if indexBuildErrorMessage != nil {
+            return .red
+        }
+        switch indexStatus {
+        case .ready:
+            return .green
+        case .notBuilt, .needsRebuild:
+            return .secondary
+        }
+    }
+
+    private var indexStatusMessageText: String {
+        if let indexBuildErrorMessage {
+            return indexBuildErrorMessage
+        }
+        return indexBuildMessage ?? ""
+    }
+
+    private var indexStatusMessageColor: Color {
+        if indexBuildErrorMessage != nil {
+            return .red
+        }
+        return Color(nsColor: .secondaryLabelColor)
+    }
+
+    private var indexStatusDetailText: String {
+        if indexBuildInProgress {
+            return "辞書を保存済みキャッシュへ反映しています。入力は続けられます。"
+        }
+        switch indexStatus {
+        case .notBuilt(let entryCount):
+            return "\(entryCount)件の有効な単語が対象です。"
+        case .ready(let summary):
+            return indexSummaryText(summary)
+        case .needsRebuild(let currentEntryCount, let existing):
+            if let existing {
+                return "\(currentEntryCount)件の現在内容に対して更新が必要です。前回: \(indexSummaryText(existing))"
+            }
+            return "\(currentEntryCount)件の現在内容に対して更新が必要です。"
+        }
+    }
+
+    private func indexSummaryText(_ summary: UserDictionaryIndexSummary) -> String {
+        var parts = ["高速化済み: \(summary.indexedEntryCount)件"]
+        if summary.skippedEntryCount > 0 {
+            parts.append("直接検索: \(summary.skippedEntryCount)件")
+        }
+        if let updatedAt = summary.updatedAt {
+            parts.append("更新: \(formattedIndexDate(updatedAt))")
+        }
+        return parts.joined(separator: " / ")
+    }
+
+    private func formattedIndexDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        return formatter.string(from: date)
+    }
+
+    private func refreshIndexStatus() {
+        indexStatus = UserDictionaryIndexController.currentStatus(applicationDirectoryURL: azooKeyMemoryDirectoryURL)
+        if case .ready = indexStatus {
+            indexBuildErrorMessage = nil
+        }
+    }
+
+    private func scheduleIndexRebuildSoon() {
+        scheduledIndexBuildTask?.cancel()
+        scheduledIndexBuildTask = Task {
+            try? await Task.sleep(nanoseconds: 900_000_000)
+            guard !Task.isCancelled else {
+                return
+            }
+            await MainActor.run {
+                refreshIndexStatus()
+                rebuildIndexNow()
+            }
+        }
+    }
+
+    private func rebuildIndexNow() {
+        guard !indexBuildInProgress else {
+            return
+        }
+        scheduledIndexBuildTask?.cancel()
+        indexBuildInProgress = true
+        indexBuildErrorMessage = nil
+        indexBuildMessage = nil
+        let applicationDirectoryURL = azooKeyMemoryDirectoryURL
+        Task {
+            do {
+                let result = try await Task.detached(priority: .utility) {
+                    try UserDictionaryIndexController.rebuild(applicationDirectoryURL: applicationDirectoryURL)
+                }.value
+                await MainActor.run {
+                    self.indexBuildInProgress = false
+                    self.indexBuildMessage = self.indexBuildResultMessage(result)
+                    self.refreshIndexStatus()
+                }
+            } catch {
+                await MainActor.run {
+                    self.indexBuildInProgress = false
+                    self.indexBuildErrorMessage = "キャッシュ作成に失敗しました: \(error.localizedDescription)"
+                    self.refreshIndexStatus()
+                }
+            }
+        }
+    }
+
+    private func indexBuildResultMessage(_ result: UserDictionaryIndexBuildResult) -> String {
+        if result.skippedEntryCount > 0 {
+            return "\(result.indexedEntryCount)件を高速化用キャッシュに保存しました。\(result.skippedEntryCount)件は直接検索で候補に表示されます。"
+        }
+        return "\(result.indexedEntryCount)件を高速化用キャッシュに保存しました。"
+    }
+
     private func showAlert(_ message: String) {
         alertMessage = message
         showingAlert = true
+    }
+}
+
+private struct WindowAccessor: NSViewRepresentable {
+    @Binding var window: NSWindow?
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            self.window = view.window
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            self.window = nsView.window
+        }
+    }
+}
+
+private struct ToolbarActionButton: NSViewRepresentable {
+    var title: String
+    var systemImage: String
+    var height: CGFloat
+    var isEnabled: Bool = true
+    var action: (NSWindow?) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(title: title, target: context.coordinator, action: #selector(Coordinator.performAction(_:)))
+        button.bezelStyle = .rounded
+        button.isBordered = true
+        button.controlSize = .regular
+        button.imagePosition = .imageLeading
+        button.imageHugsTitle = true
+        button.contentTintColor = nil
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        context.coordinator.heightConstraint = button.heightAnchor.constraint(equalToConstant: height)
+        context.coordinator.heightConstraint?.isActive = true
+        updateNSView(button, context: context)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
+        context.coordinator.heightConstraint?.constant = height
+        button.title = title
+        button.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: title)
+        button.isEnabled = isEnabled
+    }
+
+    final class Coordinator: NSObject {
+        var action: (NSWindow?) -> Void
+        var heightConstraint: NSLayoutConstraint?
+
+        init(action: @escaping (NSWindow?) -> Void) {
+            self.action = action
+        }
+
+        @objc func performAction(_ sender: NSButton) {
+            action(sender.window)
+        }
     }
 }
 

--- a/azooKeyMac/azooKeyMac.entitlements
+++ b/azooKeyMac/azooKeyMac.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>group.dev.ensan.inputmethod.azooKeyMac</string>
 	</array>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-register.global-name</key>


### PR DESCRIPTION
Codexの助けを借りて作成したものです。

## 概要

macOS版のユーザー辞書機能を拡張します。

これまでの単一リスト形式のユーザー辞書を、複数の辞書を持てる形式に拡張し、辞書ごとの有効/無効、インポート、エクスポート、手動編集、検索、並び替えに対応しました。

また、ユーザー辞書のコメントを変換候補の注記として表示できるようにし、大きな辞書でも変換時の負荷が大きくなりにくいよう、保存済みインデックスを使う経路を追加しています。

## 主な変更点

### ユーザー辞書の複数管理

- ユーザー辞書内に複数の辞書を保持できるようにしました。
- 辞書ごとに有効/無効を切り替えられるようにしました。
- 既存の単一リスト形式のユーザー辞書設定は、新しい複数辞書形式へ読み替えるようにしています。
- 既存ユーザーの辞書内容を失わないよう、旧形式からの移行互換性を維持しています。

### ユーザー辞書エディタの拡張

- 辞書の新規作成に対応しました。
- 辞書削除時に確認ダイアログを出すようにしました。
- 辞書名の編集と有効/無効の切り替えに対応しました。
- 単語の手動追加、編集、削除に対応しました。
- 単語一覧を検索できるようにしました。
  - 検索対象は「単語」「読み」「コメント」です。
- 単語一覧の「単語」「読み」列をクリックして、昇順/降順で並び替えられるようにしました。

<img width="906" height="653" alt="image" src="https://github.com/user-attachments/assets/9e083acd-d7cc-4463-830d-891da36d2b53" />


### インポート / エクスポート

- ユーザー辞書ファイルの読み込みに対応しました。
- 読み込み時に、以下を選べるようにしました。
  - 新規辞書として読み込む
  - 選択中の辞書に追加する
- 選択中の辞書を書き出せるようにしました。
- Google 日本語入力形式のタブ区切りテキストをサポートしました。
- コメント/注記欄もユーザー辞書の hint として取り込むようにしました。
- 書き出し時にもコメント欄を含めて出力します。

### 変換候補へのコメント表示

- ユーザー辞書に登録されたコメントを、変換候補の横に注記として表示できるようにしました。
- コメントは、登録語と実際に表示されている候補が一致する場合だけ表示します。
- これにより、内部的に同じ読みや辞書要素を含む別候補に、無関係なコメントが表示されることを防いでいます。
- コメント表示で候補本文が隠れにくいよう、候補ウィンドウの注記表示レイアウトも調整しました。

添付画像は「りゅうすうていり」と入力時のもので、ユーザー辞書に登録されているコメントの表示例を示しています

<img width="454" height="235" alt="image" src="https://github.com/user-attachments/assets/3f1a95b0-a5b6-4449-b46c-d979959b11c6" />


### 大きな辞書向けの高速化

- 変換時に毎回 UserDefaults 上の辞書を走査し続けないよう、ユーザー辞書の保存済みインデックスを追加しました。
- 辞書内容が変わったときに revision を更新し、必要に応じてインデックスを再作成します。
- インデックス化できる項目は保存済みインデックス経由で扱います。
- インデックス化できない項目は、従来の動的検索経路で候補に出せるようにしています。
- そのため、インデックス対象外の項目も辞書候補から消えないようにしています。

## 実装上の注意

変換候補の注記表示は、意図的に保守的にしています。

以前の実装では、候補の内部データにユーザー辞書由来の語が含まれているだけでコメントを表示すると、実際には登録していない候補にもコメントが出る可能性がありました。

このPRでは、候補として表示されている文字列と、ユーザー辞書に登録された単語が一致する場合だけコメントを表示します。

また、大きな辞書への対応では、候補数を単純に上限で切るような変更はしていません。変換精度を落とさないため、候補を雑に削るのではなく、辞書検索の経路をインデックス化する方向にしています。

## 検証

以下を実行しました。

- `swift test --disable-sandbox --package-path Core --build-path /private/tmp/azookey-pr-core-final-build`
  - 40 tests passed
- `git diff --check upstream/main`
- `plutil -lint azooKeyMac/azooKeyMac.entitlements`
- `xcrun swiftc -parse azooKeyMac/Windows/UserDictionaryEditorWindow.swift`

いずれも成功しています。
