### PR TITLE
fix: Ctrlキーの組み合わせを適切に処理できるように修正

### DIFF
--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -119,6 +119,7 @@ public enum UserAction {
                 }
             }
         }
+
         // Resolve action based on logical key character (ignoring modifiers)
         if let logicalKey = eventCore.charactersIgnoringModifiers?.lowercased() {
             switch (logicalKey, eventCore.modifierFlags) {
@@ -156,9 +157,6 @@ public enum UserAction {
                 return .suggest
             case ("u", [.control, .shift]): // Shift + Control + u
                 return .startUnicodeInput
-            case (_, let modifierFlags) where modifierFlags.contains(.control):
-                // Controlが押されているが、上記のどのショートカットにも当てはまらない場合は、未知のアクションとして扱う
-                return .unknown
 
             case ("¥", [.shift, .option]), ("¥", [.shift]), ("\\", [.shift, .option]), ("\\", [.shift]):
                 return .input(keyMap("|"))
@@ -197,6 +195,14 @@ public enum UserAction {
                 break
             }
         }
+
+        if eventCore.modifierFlags.contains(.control), eventCore.keyCode != 51 {
+            // logicalKeyで既知のControlショートカットを処理した後、
+            // 後続の物理キー処理をする前に未定義のControl系をホストアプリへ渡す
+            // Ctrl+Delete(keyCode 51)だけは.forgetとして下のDelete分岐で扱う
+            return .unknown
+        }
+
         // Resolve action based on physical key code
         switch eventCore.keyCode {
         case 0x24, 0x4C: // Enter (0x24) and Numpad Enter (0x4C)
@@ -251,7 +257,9 @@ public enum UserAction {
             // Numpadでそれぞれ「入力先頭にカーソルを移動」「入力末尾にカーソルを移動」「変換候補欄を1ページ戻る」「変換候補欄を1ページ進む」「順方向削除」「入力全消し（より強いエスケープ）」に対応するが、サポート外の動作として明示的に無効化
             return .unknown
         case 18, 19, 20, 21, 23, 22, 26, 28, 25, 29:
-            if !eventCore.modifierFlags.contains(.shift) && !eventCore.modifierFlags.contains(.option) {
+            // Control+数字はアプリやOS側のショートカットとして使われるため、数字入力としない
+            // keyCode分岐に入る前に.unknownとして処理されるが、念のためここでも明示的に扱う
+            if eventCore.modifierFlags.isDisjoint(with: [.shift, .option, .control]) {
                 let number: UserAction.Number = [
                     18: .one,
                     19: .two,

--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -46,6 +46,14 @@ public enum InputState: Sendable, Hashable {
                 return (.fallthrough, .fallthrough)
             }
         }
+        if event.modifierFlags.contains(.control) {
+            switch userAction {
+            case .unknown where self == .composing || self == .previewing || self == .selecting || self == .replaceSuggestion:
+                return (.consume, .fallthrough)
+            default:
+                break
+            }
+        }
         switch self {
         case .none:
             switch userAction {
@@ -193,12 +201,7 @@ public enum InputState: Sendable, Hashable {
                 }
             case .startUnicodeInput:
                 return (.commitMarkedText, .transition(.unicodeInput("")))
-            case .unknown:
-                if event.modifierFlags.contains(.control) {
-                    return (.consume, .fallthrough)
-                }
-                return (.fallthrough, .fallthrough)
-            case .transformSelectedText, .deadKey:
+            case .unknown, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .previewing:
@@ -253,12 +256,7 @@ public enum InputState: Sendable, Hashable {
                 return (.editSegment(count), .transition(.selecting))
             case .startUnicodeInput:
                 return (.commitMarkedText, .transition(.unicodeInput("")))
-            case .unknown:
-                if event.modifierFlags.contains(.control) {
-                    return (.consume, .fallthrough)
-                }
-                return (.fallthrough, .fallthrough)
-            case .suggest, .transformSelectedText, .deadKey:
+            case .unknown, .suggest, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .selecting:
@@ -343,12 +341,7 @@ public enum InputState: Sendable, Hashable {
                 return (.consume, .fallthrough)
             case .startUnicodeInput:
                 return (.submitSelectedCandidateAndEnterUnicodeInputMode, .transition(.unicodeInput("")))
-            case .unknown:
-                if event.modifierFlags.contains(.control) {
-                    return (.consume, .fallthrough)
-                }
-                return (.fallthrough, .fallthrough)
-            case .suggest, .transformSelectedText, .deadKey:
+            case .unknown, .suggest, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .replaceSuggestion:
@@ -380,12 +373,7 @@ public enum InputState: Sendable, Hashable {
                 return (.consume, .fallthrough)
             case .startUnicodeInput:
                 return (.hideReplaceSuggestionWindow, .transition(.unicodeInput("")))
-            case .unknown:
-                if event.modifierFlags.contains(.control) {
-                    return (.consume, .fallthrough)
-                }
-                return (.fallthrough, .fallthrough)
-            case .function, .number, .editSegment, .transformSelectedText, .deadKey:
+            case .unknown, .function, .number, .editSegment, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .unicodeInput(let codePoint):

--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -193,7 +193,12 @@ public enum InputState: Sendable, Hashable {
                 }
             case .startUnicodeInput:
                 return (.commitMarkedText, .transition(.unicodeInput("")))
-            case .unknown, .transformSelectedText, .deadKey:
+            case .unknown:
+                if event.modifierFlags.contains(.control) {
+                    return (.consume, .fallthrough)
+                }
+                return (.fallthrough, .fallthrough)
+            case .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .previewing:
@@ -248,7 +253,12 @@ public enum InputState: Sendable, Hashable {
                 return (.editSegment(count), .transition(.selecting))
             case .startUnicodeInput:
                 return (.commitMarkedText, .transition(.unicodeInput("")))
-            case .unknown, .suggest, .transformSelectedText, .deadKey:
+            case .unknown:
+                if event.modifierFlags.contains(.control) {
+                    return (.consume, .fallthrough)
+                }
+                return (.fallthrough, .fallthrough)
+            case .suggest, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .selecting:
@@ -333,7 +343,12 @@ public enum InputState: Sendable, Hashable {
                 return (.consume, .fallthrough)
             case .startUnicodeInput:
                 return (.submitSelectedCandidateAndEnterUnicodeInputMode, .transition(.unicodeInput("")))
-            case .unknown, .suggest, .transformSelectedText, .deadKey:
+            case .unknown:
+                if event.modifierFlags.contains(.control) {
+                    return (.consume, .fallthrough)
+                }
+                return (.fallthrough, .fallthrough)
+            case .suggest, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .replaceSuggestion:
@@ -365,7 +380,12 @@ public enum InputState: Sendable, Hashable {
                 return (.consume, .fallthrough)
             case .startUnicodeInput:
                 return (.hideReplaceSuggestionWindow, .transition(.unicodeInput("")))
-            case .unknown, .function, .number, .editSegment, .transformSelectedText, .deadKey:
+            case .unknown:
+                if event.modifierFlags.contains(.control) {
+                    return (.consume, .fallthrough)
+                }
+                return (.fallthrough, .fallthrough)
+            case .function, .number, .editSegment, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .unicodeInput(let codePoint):

--- a/Core/Tests/CoreTests/InputUtilsTests/ControlShortcutRoutingTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/ControlShortcutRoutingTests.swift
@@ -202,8 +202,87 @@ private func makeControlEvent(
         enableDebugWindow: false,
         enableSuggestion: false
     )
-    guard case .fallthrough = composingAction, case .fallthrough = composingCallback else {
-        Issue.record("Expected unknown action in composing state to fall through, got \(composingAction), \(composingCallback)")
+    // Ctrl修飾付きの.unknownはcomposing中にmarked textを保護するためconsumeに変更されている
+    guard case .consume = composingAction, case .fallthrough = composingCallback else {
+        Issue.record("Expected unknown action with Ctrl in composing state to be consumed, got \(composingAction), \(composingCallback)")
+        return
+    }
+}
+
+@Test func testCtrlUnknownIsConsumedDuringComposingStates() {
+    // Ctrl+Shift+O などの未定義 Ctrl 系キーはcomposing系状態でconsumeされ、marked textの消失を防ぐ
+    let controlShiftOEvent = makeControlEvent(
+        logicalKey: "o",
+        characters: "O",
+        modifiers: [.control, .shift],
+        keyCode: 31
+    )
+    let controlBackquoteEvent = makeControlEvent(
+        logicalKey: "`",
+        characters: "`",
+        modifiers: [.control],
+        keyCode: 50
+    )
+
+    let composingStates: [InputState] = [.composing, .previewing, .selecting, .replaceSuggestion]
+    for state in composingStates {
+        for event in [controlShiftOEvent, controlBackquoteEvent] {
+            let (action, callback) = state.event(
+                eventCore: event,
+                userAction: .unknown,
+                inputLanguage: .japanese,
+                liveConversionEnabled: false,
+                enableDebugWindow: false,
+                enableSuggestion: false
+            )
+            guard case .consume = action, case .fallthrough = callback else {
+                Issue.record("Expected Ctrl unknown to be consumed in \(state) state, got \(action), \(callback)")
+                return
+            }
+        }
+    }
+}
+
+@Test func testCtrlUnknownInNoneStateFallsThrough() {
+    // composing中でない場合は、アプリ側のショートカットが発火するようfallthroughされる
+    let controlShiftOEvent = makeControlEvent(
+        logicalKey: "o",
+        characters: "O",
+        modifiers: [.control, .shift],
+        keyCode: 31
+    )
+    let (action, callback) = InputState.none.event(
+        eventCore: controlShiftOEvent,
+        userAction: .unknown,
+        inputLanguage: .japanese,
+        liveConversionEnabled: false,
+        enableDebugWindow: false,
+        enableSuggestion: false
+    )
+    guard case .fallthrough = action, case .fallthrough = callback else {
+        Issue.record("Expected Ctrl+Shift unknown in none state to fall through, got \(action), \(callback)")
+        return
+    }
+}
+
+@Test func testNonModifierUnknownStillFallsThroughDuringComposing() {
+    // Ctrlを伴わない.unknownは従来通りfallthroughされる（既存挙動の回帰防止）
+    let bareEvent = makeControlEvent(
+        logicalKey: nil,
+        characters: nil,
+        modifiers: [],
+        keyCode: 0
+    )
+    let (action, callback) = InputState.composing.event(
+        eventCore: bareEvent,
+        userAction: .unknown,
+        inputLanguage: .japanese,
+        liveConversionEnabled: false,
+        enableDebugWindow: false,
+        enableSuggestion: false
+    )
+    guard case .fallthrough = action, case .fallthrough = callback else {
+        Issue.record("Expected modifier-less unknown in composing state to fall through, got \(action), \(callback)")
         return
     }
 }

--- a/Core/Tests/CoreTests/InputUtilsTests/ControlShortcutRoutingTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/ControlShortcutRoutingTests.swift
@@ -1,0 +1,209 @@
+import Core
+import Testing
+
+private func makeControlEvent(
+    logicalKey: String?,
+    characters: String?,
+    modifiers: KeyEventCore.ModifierFlag,
+    keyCode: UInt16
+) -> KeyEventCore {
+    KeyEventCore(
+        modifierFlags: modifiers,
+        characters: characters,
+        charactersIgnoringModifiers: logicalKey,
+        keyCode: keyCode
+    )
+}
+
+@Test func testUnhandledControlShortcutsAreNotConvertedToInput() {
+    let controlBackquote = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: "`",
+            characters: "`",
+            modifiers: [.control],
+            keyCode: 50
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .unknown = controlBackquote else {
+        Issue.record("Expected Ctrl+` to be unknown, got \(controlBackquote)")
+        return
+    }
+
+    let controlShiftO = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: "o",
+            characters: "O",
+            modifiers: [.control, .shift],
+            keyCode: 31
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .unknown = controlShiftO else {
+        Issue.record("Expected Ctrl+Shift+O to be unknown, got \(controlShiftO)")
+        return
+    }
+
+    let numberKeyCodes: [(logicalKey: String, keyCode: UInt16)] = [
+        ("1", 18),
+        ("2", 19),
+        ("3", 20),
+        ("4", 21),
+        ("5", 23),
+        ("6", 22),
+        ("7", 26),
+        ("8", 28),
+        ("9", 25),
+        ("0", 29)
+    ]
+    for (logicalKey, keyCode) in numberKeyCodes {
+        let controlNumber = UserAction.getUserAction(
+            eventCore: makeControlEvent(
+                logicalKey: logicalKey,
+                characters: logicalKey,
+                modifiers: [.control],
+                keyCode: keyCode
+            ),
+            inputLanguage: .japanese
+        )
+        guard case .unknown = controlNumber else {
+            Issue.record("Expected Ctrl+\(logicalKey) to be unknown, got \(controlNumber)")
+            return
+        }
+    }
+
+    let controlSpace = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: " ",
+            characters: " ",
+            modifiers: [.control],
+            keyCode: 49
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .unknown = controlSpace else {
+        Issue.record("Expected Ctrl+Space to be unknown, got \(controlSpace)")
+        return
+    }
+
+    let controlLeft = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: nil,
+            characters: nil,
+            modifiers: [.control],
+            keyCode: 123
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .unknown = controlLeft else {
+        Issue.record("Expected Ctrl+Left to be unknown, got \(controlLeft)")
+        return
+    }
+}
+
+@Test func testKnownControlShortcutsKeepTheirActions() {
+    let controlDelete = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: nil,
+            characters: nil,
+            modifiers: [.control],
+            keyCode: 51
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .forget = controlDelete else {
+        Issue.record("Expected Ctrl+Delete to be forget, got \(controlDelete)")
+        return
+    }
+
+    let controlH = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: "h",
+            characters: "\u{08}",
+            modifiers: [.control],
+            keyCode: 4
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .backspace = controlH else {
+        Issue.record("Expected Ctrl+H to be backspace, got \(controlH)")
+        return
+    }
+
+    let controlJ = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: "j",
+            characters: "\n",
+            modifiers: [.control],
+            keyCode: 38
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .function(.six) = controlJ else {
+        Issue.record("Expected Ctrl+J to be function(.six), got \(controlJ)")
+        return
+    }
+
+    let controlSemicolon = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: ";",
+            characters: ";",
+            modifiers: [.control],
+            keyCode: 41
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .function(.eight) = controlSemicolon else {
+        Issue.record("Expected Ctrl+; to be function(.eight), got \(controlSemicolon)")
+        return
+    }
+
+    let controlShiftU = UserAction.getUserAction(
+        eventCore: makeControlEvent(
+            logicalKey: "u",
+            characters: "U",
+            modifiers: [.control, .shift],
+            keyCode: 32
+        ),
+        inputLanguage: .japanese
+    )
+    guard case .startUnicodeInput = controlShiftU else {
+        Issue.record("Expected Ctrl+Shift+U to be startUnicodeInput, got \(controlShiftU)")
+        return
+    }
+}
+
+@Test func testUnknownActionsFallThroughToHostApplication() {
+    let controlBackquoteEvent = makeControlEvent(
+        logicalKey: "`",
+        characters: "`",
+        modifiers: [.control],
+        keyCode: 50
+    )
+
+    let (noneAction, noneCallback) = InputState.none.event(
+        eventCore: controlBackquoteEvent,
+        userAction: .unknown,
+        inputLanguage: .japanese,
+        liveConversionEnabled: false,
+        enableDebugWindow: false,
+        enableSuggestion: false
+    )
+    guard case .fallthrough = noneAction, case .fallthrough = noneCallback else {
+        Issue.record("Expected unknown action in none state to fall through, got \(noneAction), \(noneCallback)")
+        return
+    }
+
+    let (composingAction, composingCallback) = InputState.composing.event(
+        eventCore: controlBackquoteEvent,
+        userAction: .unknown,
+        inputLanguage: .japanese,
+        liveConversionEnabled: false,
+        enableDebugWindow: false,
+        enableSuggestion: false
+    )
+    guard case .fallthrough = composingAction, case .fallthrough = composingCallback else {
+        Issue.record("Expected unknown action in composing state to fall through, got \(composingAction), \(composingCallback)")
+        return
+    }
+}


### PR DESCRIPTION
## 概要・背景

PR #310 では未定義のCtrl系キーをIMEで処理しないようにしましたが、処理が不十分で一部のCtrlの組み合わせの入力に影響が出てしまいました。

このPRでは、既知のCtrlショートカットをlogicalKey側で処理した後、未定義のCtrl系キーをkeyCodeでの処理へ落とさず 早期に`.unknown` で返すことで、ホストアプリ側へ渡すようにして、アプリのショートカットが適切に動作するように修正します。

加えて、composing中（変換中の入力がある状態）に未定義のCtrl修飾付きキー（例: `Ctrl+Shift+O`）が発火されると、Discordなどの一部アプリで変換中の入力が消失する問題があったため、composing系状態ではIME側で `.consume` して入力を保護します。

## 関連Issue

Related to #310

## 変更内容

- logicalKeyで既知のCtrlショートカットを処理した後に、未定義のCtrl系キーを `.unknown` に分類
- `Ctrl+Delete` は既存仕様の `.forget` として維持
- `Ctrl+数字` が数字入力として扱われないよう、数字キー分岐でも `.control` を明示的に除外
- `InputState` の composing / previewing / selecting / replaceSuggestion で `.unknown` 分岐を分離し、Ctrl修飾を含む場合は `.consume` を返して入力テキストを保護
- 未定義Ctrl系、既知Ctrlショートカット、`.unknown` のfallthrough/consumeを検証するテストを追加

## 詳細

### 処理の流れ

変更前は、`UserAction.getUserAction` の処理が大きく次の流れになっていました。

| 段階 | 内容 |
| --- | --- |
| 1 | `charactersIgnoringModifiers` から logicalKey を取得する |
| 2 | logicalKey ブロック内で既知のショートカットや記号入力を判定する(PR #310 で追加された `control` 修飾を含む未定義キーを `.unknown` にする) |
| 3 | logicalKey で処理されなかった場合、`keyCode` ブロックで Space / Delete / 矢印 / 数字などの物理キーを判定する |
| 4 | 最後に printable な文字を `.input` として扱う |

この構造では、`control` 修飾を含む未定義キーの判定が logicalKey ブロック内にありました。

変更後は、処理の流れを次のように整理しています。

| 段階 | 内容 |
| --- | --- |
| 1 | `charactersIgnoringModifiers` から logicalKey を取得する |
| 2 | logicalKey ブロック内で、azooKey が明示的に対応している `Ctrl+H`, `Ctrl+J`, `Ctrl+;`, `Ctrl+Shift+U` などを処理する |
| 3 | logicalKey ブロックで処理されなかった `control` 修飾付きキーを、`keyCode` ブロックへ入る前に `.unknown` にする(ただし `Ctrl+Delete` は既存仕様の `.forget` として扱うため、4へ通す) |
| 4 | `control` 修飾を含まない通常キーを `keyCode` ブロックで処理する |
| 5 | 最後に printable な文字を `.input` として扱う |

これにより、既存の `logicalKey -> keyCode -> fallback` という大枠は維持しつつ、未定義の `control` 系キーがkeyCode処理へ落ちないようにしています。

### 発生していた問題と解決方法

#### `Ctrl + Delete`が動作しなくなっていた

1つ目は、`control` 修飾付きキーを logicalKey ブロック内でまとめて `.unknown` にしていたため、後続の `keyCode` ブロックにある `Ctrl+Delete` の処理まで到達できなくなったことです。  
`Ctrl+Delete` は既存仕様として `.forget` に対応していましたが、logicalKey ブロックで先に `.unknown` になってしまうと、下記の Delete 分岐へ到達できていませんでした。  
このPRでは、明示的に`Ctrl + Delete`を分岐で扱うことで修正しました。

#### 一部の`Ctrl +`系のキーが適切に処理されていなかった

2つ目は、`charactersIgnoringModifiers` が取得できないキーや、logicalKey ブロックで処理されずにkeyCode側で処理されるキーでは、未定義の `control` 系キーが `Space`、矢印、数字などとして処理される可能性が残っていたことです。

例えば以下のようなケースです。

| 入力 | 望ましい動作 | 問題がある場合の動作 |
| --- | --- | --- |
| `Ctrl+Space` | ホストアプリへ渡す | `.space` として処理され、スペース入力や変換操作になる |
| `Ctrl+Left` | ホストアプリへ渡す | `.navigation(.left)` として azooKey 側で消費される |
| `Ctrl+1` | ホストアプリへ渡す | `.number(.one)` として処理される |
| `Ctrl+Shift+O` | ホストアプリへ渡す | `.input` や `.unknown` の扱いが処理位置に依存する |

今回の修正では、まず logicalKey ブロックで azooKey が明示的に対応している `control` 系ショートカットだけを処理します。その後、`keyCode` ブロックに入る前に、未定義の `control` 系キーを `.unknown` として返します。
これにより、`Ctrl+Space`、`Ctrl+Left`、`Ctrl+数字` などがkeyCode処理へ落ちず、ホストアプリへ fallthrough されるようになります。

さらに、数字キー分岐でも `.control` を明示的に除外しています。

#### 変換中にCtrl系が入力されるとテキストが破棄されてしまった

3つ目は、composing中（変換中の入力がある状態）に未定義のCtrl修飾付きキー（例: `Ctrl+Shift+O`）が押されたとき、`.unknown` がホストアプリへ fallthrough される過程で、Discordなどの一部アプリがテキストを破棄してしまい、変換中の入力が消失する問題です。

`UserAction` 側で `.unknown` に分類してホストへ委譲する方針を維持しつつも、composing系状態では入力を保護したいので、`InputState` の `composing` / `previewing` / `selecting` / `replaceSuggestion` の各状態で `.unknown` 分岐を他のケースから分離し、`.control` 修飾を含むイベントは `.consume` を返すようにしました。

これにより、

- composing系状態でCtrl修飾付きの `.unknown` が来た場合: IME側で `.consume` して変換文字列を保持
- `.none` 状態でCtrl修飾付きの `.unknown` が来た場合: 従来通り `.fallthrough` してアプリ側のショートカットを発火
- modifier を含まない `.unknown` が来た場合: 従来通り `.fallthrough`

という動作になります。

## 追加したテスト

| テスト | 入力 | 期待結果 | 目的 |
| --- | --- | --- | --- |
| 未定義Controlキー | `` Ctrl+` `` | `.unknown` | 未定義のControl系キーを文字入力にしないことを確認 |
| 未定義Control+Shiftキー | `Ctrl+Shift+O` | `.unknown` | Discordなどで問題になったControl+Shift+文字をIME側で消費しないことを確認 |
| Control+数字 | `Ctrl+0` 〜 `Ctrl+9` | `.unknown` | 数字入力や候補選択として扱われないことを確認 |
| Control+Space | `Ctrl+Space` | `.unknown` | `.space` として処理されず、ホストアプリへ渡ることを確認 |
| Control+矢印 | `Ctrl+Left` | `.unknown` | `.navigation(.left)` として消費されないことを確認 |
| 既存Controlショートカット | `Ctrl+Delete` | `.forget` | 既存のforget動作が維持されることを確認 |
| 既存Controlショートカット | `Ctrl+H` | `.backspace` | 既存のbackspace動作が維持されることを確認 |
| 既存Controlショートカット | `Ctrl+J` | `.function(.six)` | 既存のF6相当の変換動作が維持されることを確認 |
| 既存Controlショートカット | `Ctrl+;` | `.function(.eight)` | 既存のF8相当の変換動作が維持されることを確認 |
| 既存Control+Shiftショートカット | `Ctrl+Shift+U` | `.startUnicodeInput` | Unicode入力モード開始が維持されることを確認 |
| fallthrough | `.unknown` in `InputState.none` | `.fallthrough` | 未定義Controlキーがホストアプリへ渡ることを確認 |
| consume | `` Ctrl+` `` / `Ctrl+Shift+O` in `composing` / `previewing` / `selecting` / `replaceSuggestion` | `.consume` | composing系状態でCtrl修飾付き `.unknown` がIME側で消費されmarked textを保護することを確認 |
| fallthrough | `Ctrl+Shift+O` in `InputState.none` | `.fallthrough` | composing中でない場合はアプリ側のショートカットへ渡ることを確認 |
| fallthrough | modifierなし `.unknown` in `InputState.composing` | `.fallthrough` | Ctrlを伴わない `.unknown` は従来通りfallthroughされることを確認（既存挙動の回帰防止） |

## テスト方法

```bash
swift test --package-path Core
```