### PR TITLE
fix: 英語入力への切り替えショートカット(Ctrl+shift+;)使用時に入力される文字が英語にならない問題を修正

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -221,9 +221,13 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
 
             if englishMode {
                 // 英語モードへの切り替え通知（実際の処理はhandleで行う）
-                // メニューバー経由の切り替えに対応
-                if self.inputLanguage == .japanese && self.segmentsManager.isEmpty {
+                // メニューバーやshortcut経由の切り替えに対応する。
+                // composing中でも英数キーMarkedTextを保ったまま英語入力へ移る。
+                if self.inputLanguage == .japanese {
                     self.inputLanguage = .english
+                    self.segmentsManager.stopJapaneseInput()
+                    self.refreshCandidateWindow()
+                    self.refreshPredictionWindow()
                 }
             } else {
                 // 日本語モードへの切り替え


### PR DESCRIPTION
## Summary

- 英語入力への切り替えショートカット使用時、composing 中でも内部状態を `.english` に同期するようにしました
- 変換中の文字列は保持したまま、日本語変換中の候補・予測ウィンドウを閉じるようにしました
- `Ctrl+Shift+;` 経由でも、英数キー1回押しと同様に以後の入力が英語として入るようにしました

## Background

#315 の[コメント](https://github.com/azooKey/azooKey-Desktop/pull/315#issuecomment-4289479160)で、composing 中に `Ctrl+Shift+;` で英語入力へ切り替えた後も、次の入力が日本語入力として処理されてしまう問題が指摘されていました。

> composingじゃない状態での切り替えは成立してる。ただ、それ以外がちょっと変。

期待される挙動は、元コメントの例にあるように、英数キーで切り替えた場合と同じ動作になることです。

```text
1. 日本語IMで「a」を入力→composingで「あ」が出る
2. 英語IMに英数キーで切り替えて「a」を入力→composingで「あa」になる
```

一方で、修正前は `Ctrl+Shift+;` で切り替えた後も内部状態が日本語入力のまま残っていたため、次の入力が日本語として処理されていました。

```text
1. 日本語IMで「a」を入力→composingで「あ」が出る
2. ctrl+shift+;を入力して「a」を入力→composingで「ああ」になる
```

このPRでは、英語入力モードへの切り替え通知を受けた時点で、未確定入力が残っていても内部状態を英語に同期するようにしています。`stopJapaneseInput()` により日本語変換の候補状態は止めますが、変換中の文字列自体は保持します。

## Test plan

- [x] 実機で Spotlight を開き、日本語IMで `a` → `Ctrl+Shift+;` → `a` の結果が `あa` になることを確認します
- [x] composing していない状態で `Ctrl+Shift+;` により英語入力へ切り替わることを確認します
- [x] 通常の英数キー1回押しと同等の挙動になっていることを確認します


https://github.com/user-attachments/assets/b4b33297-5560-4c52-a35f-10d02d92e93c

