### PR TITLE
bug: ユーザ辞書編集後に設定画面の「N件のアイテム」表示が更新されない

### DIFF
--- a/azooKeyMac/Windows/ConfigState.swift
+++ b/azooKeyMac/Windows/ConfigState.swift
@@ -1,26 +1,77 @@
+import Combine
 import Core
+import Foundation
 import SwiftUI
 
-/// Wrapper of `State` for SwiftUI. By using this wrapper, you can update config and immediately get the view update.
+/// Wrapper of `State` for SwiftUI. By using this wrapper, you can update config and immediately
+/// get the view update. The wrapper also subscribes to `UserDefaults.didChangeNotification`,
+/// so a config update made from another window — or via a direct `wrappedValue.value` mutation —
+/// re-renders any view that holds a `ConfigState` for that item.
 @propertyWrapper
 struct ConfigState<Item: ConfigItem>: DynamicProperty {
-    @State private var underlyingState: Item.Value
+    @StateObject private var store: ConfigStateStore<Item>
+
+    private let item: Item
 
     init(wrappedValue: Item) {
-        self._underlyingState = .init(initialValue: wrappedValue.value)
-        self.wrappedValue = wrappedValue
+        self.item = wrappedValue
+        self._store = StateObject(wrappedValue: ConfigStateStore(item: wrappedValue))
     }
 
-    var wrappedValue: Item
+    var wrappedValue: Item {
+        self.item
+    }
+
     var projectedValue: Binding<Item.Value> {
         Binding(
-            get: {
-                self.underlyingState
-            },
-            set: {
-                self.underlyingState = $0
-                self.wrappedValue.value = $0
-            }
+            get: { self.store.value },
+            set: { self.store.set($0) }
         )
+    }
+}
+
+/// Backing store for `ConfigState`. Observes `UserDefaults.didChangeNotification` so
+/// out-of-band writes (other windows, direct `Item.value` mutation) still notify SwiftUI.
+///
+/// `@MainActor`-isolated because it owns SwiftUI-facing `@Published` state. Observer
+/// callbacks are scheduled on `.main` already; we still hop through a `Task { @MainActor }`
+/// for type-level isolation since `MainActor.assumeIsolated` requires macOS 14+.
+@MainActor
+private final class ConfigStateStore<Item: ConfigItem>: ObservableObject {
+    @Published private(set) var value: Item.Value
+
+    private let item: Item
+    private var observer: NSObjectProtocol?
+
+    init(item: Item) {
+        self.item = item
+        self.value = item.value
+
+        // `didChangeNotification` does not carry the changed key, so we reload regardless
+        // and rely on SwiftUI / @Published to coalesce updates per run loop tick.
+        self.observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.reload()
+            }
+        }
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func set(_ newValue: Item.Value) {
+        self.value = newValue
+        self.item.value = newValue
+    }
+
+    private func reload() {
+        self.value = self.item.value
     }
 }

--- a/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
+++ b/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
@@ -29,8 +29,25 @@ struct UserDictionaryEditorWindow: View {
         }
     }
 
+    /// Read the current user dictionary value through the `@ConfigState` binding (i.e. the
+    /// in-memory store) instead of `userDictionary.value` (which decodes from UserDefaults
+    /// on every access). Writes still go through `updateUserDictionary` below.
+    private var userDictionaryValue: Config.UserDictionary.Value {
+        self.$userDictionary.wrappedValue
+    }
+
     private var isAdditionDisabled: Bool {
-        self.userDictionary.value.items.count >= 50
+        self.userDictionaryValue.items.count >= 50
+    }
+
+    /// Mutate the user dictionary through the `@ConfigState` binding so the backing store and
+    /// any other window observing the same item are kept in sync. Direct `userDictionary.value`
+    /// mutation only writes to UserDefaults and bypasses the store, which left "x件のアイテム"
+    /// counts stale in other views (see fix/user-dictionary-count-update).
+    private func updateUserDictionary(_ transform: (inout Config.UserDictionary.Value) -> Void) {
+        var value = self.$userDictionary.wrappedValue
+        transform(&value)
+        self.$userDictionary.wrappedValue = value
     }
 
     var body: some View {
@@ -44,15 +61,15 @@ struct UserDictionaryEditorWindow: View {
             if let editTargetID {
                 let itemBinding = Binding(
                     get: {
-                        self.userDictionary.value.items.first {
+                        self.userDictionaryValue.items.first {
                             $0.id == editTargetID
                         } ?? .init(word: "", reading: "")
                     },
-                    set: {
-                        if let index = self.userDictionary.value.items.firstIndex(where: {
-                            $0.id == editTargetID
-                        }) {
-                            self.userDictionary.value.items[index] = $0
+                    set: { newItem in
+                        self.updateUserDictionary { value in
+                            if let index = value.items.firstIndex(where: { $0.id == editTargetID }) {
+                                value.items[index] = newItem
+                            }
                         }
                     }
                 )
@@ -73,7 +90,9 @@ struct UserDictionaryEditorWindow: View {
                     Spacer()
                     Button("追加", systemImage: "plus") {
                         let newItem = Config.UserDictionaryEntry(word: "", reading: "", hint: nil)
-                        self.userDictionary.value.items.append(newItem)
+                        self.updateUserDictionary { value in
+                            value.items.append(newItem)
+                        }
                         self.editTargetID = newItem.id
                         self.undoItem = nil
                     }
@@ -84,7 +103,9 @@ struct UserDictionaryEditorWindow: View {
                     }
                     if let undoItem {
                         Button("元に戻す", systemImage: "arrow.uturn.backward") {
-                            self.userDictionary.value.items.append(undoItem)
+                            self.updateUserDictionary { value in
+                                value.items.append(undoItem)
+                            }
                             self.undoItem = nil
                         }
                     }
@@ -93,7 +114,7 @@ struct UserDictionaryEditorWindow: View {
             }
             HStack {
                 Spacer()
-                Table(self.userDictionary.value.items) {
+                Table(self.userDictionaryValue.items) {
                     TableColumn("") { item in
                         HStack {
                             Button("編集する", systemImage: "pencil") {
@@ -103,11 +124,11 @@ struct UserDictionaryEditorWindow: View {
                             .buttonStyle(.bordered)
                             .labelStyle(.iconOnly)
                             Button("削除する", systemImage: "trash", role: .destructive) {
-                                if let itemIndex = self.userDictionary.value.items.firstIndex(where: {
-                                    $0.id == item.id
-                                }) {
-                                    self.undoItem = self.userDictionary.value.items[itemIndex]
-                                    self.userDictionary.value.items.remove(at: itemIndex)
+                                self.updateUserDictionary { value in
+                                    if let itemIndex = value.items.firstIndex(where: { $0.id == item.id }) {
+                                        self.undoItem = value.items[itemIndex]
+                                        value.items.remove(at: itemIndex)
+                                    }
                                 }
                             }
                             .buttonStyle(.bordered)


### PR DESCRIPTION
## 問題

Closes #327

azooKey 設定画面の「azooKeyユーザ辞書」セクションに表示される **「N件のアイテム」** のカウントが、ユーザ辞書編集ウィンドウで項目を追加・削除しても更新されない不具合の修正です。
設定画面で別の操作をして view が再描画されると最新の件数になるため、データの保存自体は行われていることが確認できます。

## 原因

`@ConfigState` プロパティラッパーの内部実装と、ユーザ辞書編集ウィンドウ側の書き込みパターンの組み合わせが原因でした。

修正前の `@ConfigState` は、内部に `@State private var underlyingState: Item.Value` を保持し、`projectedValue`（Binding）経由の書き込みでのみ `underlyingState` を更新する設計になっていました。

```swift
// 修正前
@propertyWrapper
struct ConfigState<Item: ConfigItem>: DynamicProperty {
    @State private var underlyingState: Item.Value

    init(wrappedValue: Item) {
        self._underlyingState = .init(initialValue: wrappedValue.value)
        self.wrappedValue = wrappedValue
    }

    var wrappedValue: Item
    var projectedValue: Binding<Item.Value> {
        Binding(
            get: { self.underlyingState },
            set: {
                self.underlyingState = $0
                self.wrappedValue.value = $0   // UserDefaults 書き込み
            }
        )
    }
}
```

設定画面 (`ConfigWindow`) と編集ウィンドウ (`UserDictionaryEditorWindow`) は `AppDelegate` でそれぞれ独立した `NSHostingController` として生成されるため、同じ `Config.UserDictionary` を参照していてもそれぞれ別々の `@ConfigState` インスタンス（= 別々の `@State`）を持ちます。

一方、編集ウィンドウ側は **Binding を経由せず** 直接 mutation していました:

```swift
// 修正前（UserDictionaryEditorWindow.swift）
self.userDictionary.value.items.append(newItem)
```

これは `Item.value` の computed property setter 経由で UserDefaults だけを更新する経路です。設定画面側の `@State` は更新されないうえ、設定画面には body 再評価のトリガーが何も発生しないため、`Text("\(self.userDictionary.value.items.count)件のアイテム")` は古い `@State` の世代のまま再描画されず、件数表示が更新されない症状が発生していました。

なお、編集ウィンドウ自身は同じハンドラ内で `editTargetID` / `undoItem` (`@State`) を更新していたため、たまたま body が再評価されて表示が更新される副次的挙動になっており、「自分の画面では更新されるのに、設定画面では更新されない」という挙動になっていました。

## 修正内容

### 1. `@ConfigState` を `@StateObject` + `ConfigStateStore` ベースに変更

`azooKeyMac/Windows/ConfigState.swift` の内部実装を、`@State` ベースから `@StateObject` で所有する `ObservableObject` ストアに置き換えました。

```swift
@MainActor
private final class ConfigStateStore<Item: ConfigItem>: ObservableObject {
    @Published private(set) var value: Item.Value

    private let item: Item
    private var observer: NSObjectProtocol?

    init(item: Item) {
        self.item = item
        self.value = item.value

        self.observer = NotificationCenter.default.addObserver(
            forName: UserDefaults.didChangeNotification,
            object: UserDefaults.standard,
            queue: .main
        ) { [weak self] _ in
            Task { @MainActor in
                self?.reload()
            }
        }
    }
    // ...
}
```

- `UserDefaults.didChangeNotification` を購読することで、別ウィンドウからの書き込み・直 `value` mutation を含む**プロセス内のあらゆる UserDefaults 更新**で `store.value` を reload します。`@Published` 経由で `objectWillChange` が発火し、subscribe 側の view が再評価されるため、別ウィンドウで行われた変更も即時反映されます。
- `ConfigStateStore` は SwiftUI-facing な UI state を持つため `@MainActor` で隔離。`queue: .main` で main thread に乗りますが、型レベルの isolation のため `Task { @MainActor in }` で hop しています。`MainActor.assumeIsolated` を使えば 1 hop 減らせますが macOS 14+ なので採用していません。
- observer は `[weak self]` で循環参照を回避し、`@StateObject` の lifetime に追従して `deinit` で removeObserver します。

### 2. ユーザ辞書編集ウィンドウの mutation を `updateUserDictionary` ヘルパに集約

`azooKeyMac/Windows/UserDictionaryEditorWindow.swift` の追加・削除・編集・undo の各処理を、`$userDictionary` (Binding) 経由の read-modify-write に統一しました。

```swift
private func updateUserDictionary(_ transform: (inout Config.UserDictionary.Value) -> Void) {
    var value = self.$userDictionary.wrappedValue
    transform(&value)
    self.$userDictionary.wrappedValue = value
}

// 使い方
Button("追加", systemImage: "plus") {
    let newItem = Config.UserDictionaryEntry(word: "", reading: "", hint: nil)
    self.updateUserDictionary { value in
        value.items.append(newItem)
    }
    // ...
}
```

Binding setter 経由で書き込むことで `store.set` → `@Published value` 更新 → UserDefaults 書き込み が同期的に行われ、通知の reload を待たずに自 view の即時反映も担保されます。

### 3. read 経路を `userDictionaryValue` (= `$userDictionary.wrappedValue`) に統一

editor 内の `isAdditionDisabled` / `itemBinding.get` / `Table(...)` の参照も in-memory な store 経由に揃えました。

```swift
private var userDictionaryValue: Config.UserDictionary.Value {
    self.$userDictionary.wrappedValue
}

private var isAdditionDisabled: Bool {
    self.userDictionaryValue.items.count >= 50
}
```

これまで `self.userDictionary.value.items.count` のように `Item.value` の computed property（毎回 UserDefaults を JSON decode）経由で読んでいた箇所を、`store.value` を直接読む形に変更。「**表示は store、保存は Binding setter**」という構図が明確になり、body 評価ごとのデコードコストも軽減されます。

## 動作確認

- [x] `xcodebuild -scheme azooKeyMac -configuration Debug build CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED**
- [x] 設定画面と編集ウィンドウを開いた状態で、編集ウィンドウから項目を**追加**すると設定画面の件数表示が即時に増えることを目視確認
- [x] 編集ウィンドウから項目を**削除**すると設定画面の件数表示が即時に減ることを目視確認
- [x] 削除直後の **「元に戻す」** ボタンで件数表示が元に戻ることを目視確認
- [x] 既存項目の**編集**（単語・読み・ヒントの変更）が反映され、件数が変わらないことを確認