### PR TITLE
fix(macOS): Converterを入力セッション間で共有する

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -68,7 +68,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "5ee94c1879e9189d6c76f0740c3cb09952df5599", traits: kanaKanjiConverterTraits),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "67ec8e68d17a534b5b9929b920995ef3811e89fe", traits: kanaKanjiConverterTraits),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.0")
     ],

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -68,7 +68,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "8e3a6eb89e088efd868aa28dadb74c697df4e6fb", traits: kanaKanjiConverterTraits),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "5ee94c1879e9189d6c76f0740c3cb09952df5599", traits: kanaKanjiConverterTraits),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.0")
     ],

--- a/Core/Sources/ConverterServer/ConverterServer+KeyEvent.swift
+++ b/Core/Sources/ConverterServer/ConverterServer+KeyEvent.swift
@@ -20,6 +20,14 @@ extension ConverterServer {
                 actual: request.eventID
             )
         }
+        if let activation = request.activation {
+            session.config = activation.config
+            session.inputLanguage = activation.inputLanguage
+            if activation.inputLanguage == .english {
+                session.manager.stopJapaneseInput()
+            }
+            session.manager.activate()
+        }
         session.setContext(request.context)
         Config.DebugPredictiveTyping().value = request.enablePredictiveTyping
         Config.DebugTypoCorrection().value = request.enableTypoCorrection

--- a/Core/Sources/ConverterServer/ConverterServer+Snapshot.swift
+++ b/Core/Sources/ConverterServer/ConverterServer+Snapshot.swift
@@ -86,7 +86,7 @@ extension ConverterServer {
     }
 
     @MainActor
-    static func makeSegmentsManager() -> SegmentsManager {
+    static func makeSegmentsManager(kanaKanjiConverter: KanaKanjiConverter) -> SegmentsManager {
         CustomInputTableStore.registerIfExists()
         let containerURL = AppGroup.containerURL()
         let applicationDirectoryURL = AppGroup.memoryDirectoryURL()
@@ -102,7 +102,7 @@ extension ConverterServer {
             withIntermediateDirectories: true
         )
         return SegmentsManager(
-            kanaKanjiConverter: KanaKanjiConverter.withDefaultDictionary(),
+            kanaKanjiConverter: kanaKanjiConverter,
             applicationDirectoryURL: applicationDirectoryURL,
             containerURL: containerURL,
             context: .init(useZenzai: true, resourcesDirectoryURL: appResourcesDirectoryURL())

--- a/Core/Sources/ConverterServer/ConverterSession.swift
+++ b/Core/Sources/ConverterServer/ConverterSession.swift
@@ -6,6 +6,7 @@ final class ConverterSession: SegmentManagerDelegate {
     static let replaceSuggestionContextLength = 100
 
     let manager: SegmentsManager
+    let conversionSessionID: KanaKanjiConverter.ConversionSessionID
     var inputState: InputState = .none
     var inputLanguage: InputLanguage = .japanese
     var lastHandledKeyEventID: UInt64?
@@ -21,8 +22,12 @@ final class ConverterSession: SegmentManagerDelegate {
     var replaceSuggestions: [Candidate] = []
     var replaceSuggestionSelectionIndex: Int?
 
-    init(manager: SegmentsManager) {
+    init(
+        manager: SegmentsManager,
+        conversionSessionID: KanaKanjiConverter.ConversionSessionID
+    ) {
         self.manager = manager
+        self.conversionSessionID = conversionSessionID
         self.manager.delegate = self
     }
 

--- a/Core/Sources/ConverterServer/main.swift
+++ b/Core/Sources/ConverterServer/main.swift
@@ -16,12 +16,17 @@ private enum ConverterServerXPC {
 
 final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Sendable {
     private var sessions: [String: ConverterSession] = [:]
+    private let kanaKanjiConverter = KanaKanjiConverter.withDefaultDictionary()
 
     func openSession(with reply: @escaping @Sendable (String) -> Void) {
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
                 let sessionID = UUID().uuidString
-                self.sessions[sessionID] = ConverterSession(manager: Self.makeSegmentsManager())
+                let conversionSessionID = self.kanaKanjiConverter.createSession()
+                self.sessions[sessionID] = ConverterSession(
+                    manager: Self.makeSegmentsManager(kanaKanjiConverter: self.kanaKanjiConverter),
+                    conversionSessionID: conversionSessionID
+                )
                 reply(sessionID)
             }
         }
@@ -30,7 +35,11 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
     func closeSession(_ sessionID: String, with reply: @escaping @Sendable (Bool) -> Void) {
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
-                let removed = self.sessions.removeValue(forKey: sessionID) != nil
+                let session = self.sessions.removeValue(forKey: sessionID)
+                if let session {
+                    self.kanaKanjiConverter.removeSession(session.conversionSessionID)
+                }
+                let removed = session != nil
                 reply(removed)
             }
         }
@@ -75,13 +84,12 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
             if forceExport || !CompiledUserDictionaryStore.hasExportedDictionary(memoryDirectoryURL: memoryDirectoryURL) {
                 try CompiledUserDictionaryStore.exportCurrentDictionaries(memoryDirectoryURL: memoryDirectoryURL)
             }
-            for session in sessions.values {
-                session.manager.reloadUserDictionary()
-            }
+            kanaKanjiConverter.updateUserDictionaryURL(
+                CompiledUserDictionaryStore.directoryURL(memoryDirectoryURL: memoryDirectoryURL),
+                forceReload: true
+            )
         case .resetLearningData:
-            for session in sessions.values {
-                session.manager.resetLearningData()
-            }
+            kanaKanjiConverter.resetMemory()
         }
         return ConverterServerResponse(snapshot: .empty)
     }
@@ -91,21 +99,41 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
         let session = try getSession(sessionID)
         switch command {
         case .lifecycle(let command):
-            return handle(command, session: session)
+            return try withConverterSession(session) {
+                handle(command, session: session)
+            }
         case .settings(let command):
-            return try handle(command, session: session)
+            return try withConverterSession(session) {
+                try handle(command, session: session)
+            }
         case .updateConfig(let config):
-            session.config = config
-            return makeResponse(for: session, inputState: .none)
+            return try withConverterSession(session) {
+                session.config = config
+                return makeResponse(for: session, inputState: .none)
+            }
         case .handleKeyEvent(let request):
-            return try handleKeyEvent(sessionID: sessionID, request: request)
+            return try withConverterSession(session) {
+                try handleKeyEvent(sessionID: sessionID, request: request)
+            }
         case .composition(let command):
-            return handle(command, session: session)
+            return try withConverterSession(session) {
+                handle(command, session: session)
+            }
         case .candidate(let command):
-            return handle(command, session: session)
+            return try withConverterSession(session) {
+                handle(command, session: session)
+            }
         case .replaceSuggestion(let command):
             return try await handle(command, session: session)
         }
+    }
+
+    @MainActor
+    private func withConverterSession<Result>(
+        _ session: ConverterSession,
+        operation: () throws -> Result
+    ) throws -> Result {
+        try kanaKanjiConverter.withSession(session.conversionSessionID, operation: operation)
     }
 
     @MainActor
@@ -218,23 +246,37 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
         case .request(let context):
             session.setContext(context)
             try await requestReplaceSuggestion(session: session)
-            session.inputState = .replaceSuggestion
-            return makeResponse(for: session, inputState: session.inputState, responseInputState: .replaceSuggestion)
+            return try withConverterSession(session) {
+                session.inputState = .replaceSuggestion
+                return makeResponse(
+                    for: session,
+                    inputState: session.inputState,
+                    responseInputState: .replaceSuggestion
+                )
+            }
         case .selectReplaceSuggestionCandidate(let index):
-            session.selectReplaceSuggestion(at: index)
-            session.inputState = .replaceSuggestion
-            return makeResponse(for: session, inputState: session.inputState, responseInputState: .replaceSuggestion)
+            return try withConverterSession(session) {
+                session.selectReplaceSuggestion(at: index)
+                session.inputState = .replaceSuggestion
+                return makeResponse(
+                    for: session,
+                    inputState: session.inputState,
+                    responseInputState: .replaceSuggestion
+                )
+            }
         case .submitSelectedReplaceSuggestion:
-            var effects: [ConverterClientEffect] = []
-            let didSubmit = submitSelectedReplaceSuggestion(session: session, effects: &effects)
-            let nextInputState: InputState = didSubmit ? .none : .replaceSuggestion
-            session.inputState = nextInputState
-            return makeResponse(
-                for: session,
-                inputState: nextInputState,
-                effects: effects,
-                responseInputState: ConverterInputState(nextInputState)
-            )
+            return try withConverterSession(session) {
+                var effects: [ConverterClientEffect] = []
+                let didSubmit = submitSelectedReplaceSuggestion(session: session, effects: &effects)
+                let nextInputState: InputState = didSubmit ? .none : .replaceSuggestion
+                session.inputState = nextInputState
+                return makeResponse(
+                    for: session,
+                    inputState: nextInputState,
+                    effects: effects,
+                    responseInputState: ConverterInputState(nextInputState)
+                )
+            }
         }
     }
 

--- a/Core/Sources/ConverterServer/main.swift
+++ b/Core/Sources/ConverterServer/main.swift
@@ -22,11 +22,7 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
                 let sessionID = UUID().uuidString
-                let conversionSessionID = self.kanaKanjiConverter.createSession()
-                self.sessions[sessionID] = ConverterSession(
-                    manager: Self.makeSegmentsManager(kanaKanjiConverter: self.kanaKanjiConverter),
-                    conversionSessionID: conversionSessionID
-                )
+                self.createSessionIfNeeded(sessionID)
                 reply(sessionID)
             }
         }
@@ -71,9 +67,24 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
             return ConverterServerResponse(snapshot: .empty)
         case .maintenance(let command):
             return try handle(command)
+        case .openSession(let sessionID, let command):
+            createSessionIfNeeded(sessionID)
+            return try await handle(command, sessionID: sessionID)
         case .session(let sessionID, let command):
             return try await handle(command, sessionID: sessionID)
         }
+    }
+
+    @MainActor
+    private func createSessionIfNeeded(_ sessionID: String) {
+        guard sessions[sessionID] == nil else {
+            return
+        }
+        let conversionSessionID = kanaKanjiConverter.createSession()
+        sessions[sessionID] = ConverterSession(
+            manager: Self.makeSegmentsManager(kanaKanjiConverter: kanaKanjiConverter),
+            conversionSessionID: conversionSessionID
+        )
     }
 
     @MainActor

--- a/Core/Sources/ConverterServer/main.swift
+++ b/Core/Sources/ConverterServer/main.swift
@@ -15,8 +15,11 @@ private enum ConverterServerXPC {
 }
 
 final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Sendable {
+    private static let learningDataCommitDelay: TimeInterval = 2
+
     private var sessions: [String: ConverterSession] = [:]
     private let kanaKanjiConverter = KanaKanjiConverter.withDefaultDictionary()
+    private let learningDataCommitScheduler = DebouncedActionScheduler()
 
     func openSession(with reply: @escaping @Sendable (String) -> Void) {
         DispatchQueue.main.async {
@@ -52,8 +55,14 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
             do {
                 let command = try ConverterServerCodec.decodeCommand(from: data)
                 let response = try await self.handle(command)
+                self.learningDataCommitScheduler.postponeIfScheduled(
+                    after: Self.learningDataCommitDelay
+                )
                 reply(try ConverterServerCodec.encode(response), nil)
             } catch {
+                self.learningDataCommitScheduler.postponeIfScheduled(
+                    after: Self.learningDataCommitDelay
+                )
                 reply(nil, error.localizedDescription as NSString)
             }
         }
@@ -157,7 +166,10 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
             session.manager.activate()
             return makeResponse(for: session, inputState: session.inputState)
         case .deactivate:
-            session.manager.deactivate()
+            // アプリ切替直後のキー入力を、学習データの同期I/Oで塞がない。
+            // 共有Converterはプロセス内に残るため、永続化だけ入力のアイドル時まで遅延できる。
+            session.manager.deactivate(flushLearningData: false)
+            scheduleLearningDataCommit()
             session.inputState = .none
             session.clearReplaceSuggestions()
             return makeResponse(for: session, inputState: session.inputState)
@@ -294,6 +306,13 @@ final class ConverterServer: NSObject, ConverterServerXPCProtocol, @unchecked Se
     private static func scheduleShutdown() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             exit(EXIT_SUCCESS)
+        }
+    }
+
+    @MainActor
+    private func scheduleLearningDataCommit() {
+        learningDataCommitScheduler.schedule(after: Self.learningDataCommitDelay) { [weak self] in
+            self?.kanaKanjiConverter.commitUpdateLearningData()
         }
     }
 

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -252,9 +252,11 @@ public final class SegmentsManager {
     }
 
     @MainActor
-    public func deactivate() {
+    public func deactivate(flushLearningData: Bool = true) {
         self.kanaKanjiConverter.stopComposition()
-        self.kanaKanjiConverter.commitUpdateLearningData()
+        if flushLearningData {
+            self.kanaKanjiConverter.commitUpdateLearningData()
+        }
         self.rawCandidates = nil
         self.didExperienceSegmentEdition = false
         self.lastOperation = .other

--- a/Core/Sources/Core/XPC/ConverterServerXPCProtocol.swift
+++ b/Core/Sources/Core/XPC/ConverterServerXPCProtocol.swift
@@ -41,6 +41,10 @@ public enum ConverterServerCommand: Codable, Sendable {
     /// Converter Process が所有する辞書・学習データを更新する。
     case maintenance(ConverterMaintenanceCommand)
 
+    /// セッション作成と最初の命令を1回のXPC往復で原子的に処理する。
+    /// 同じIDで再送された場合は既存セッションへ同じ命令を配送する。
+    case openSession(sessionID: String, command: ConverterSessionCommand)
+
     /// 指定したセッションへ命令を配送する。
     case session(sessionID: String, command: ConverterSessionCommand)
 }
@@ -261,7 +265,7 @@ public struct ConverterSettingDescriptor: Codable, Sendable, Equatable {
 ///
 /// Keychain や UI 状態など Client 側に残る情報を、必要な範囲だけ Server セッションへ同期する。
 /// 永続設定の一覧・更新は `ConverterSettingsCommand` が担当する。
-public struct ConverterSessionConfig: Codable, Sendable {
+public struct ConverterSessionConfig: Codable, Sendable, Equatable {
     public var aiBackendPreference: Config.AIBackendPreference.Value
     public var openAIModelName: String
     public var openAIEndpoint: String
@@ -286,7 +290,7 @@ public struct ConverterSessionConfig: Codable, Sendable {
 /// ログ出力時に値を伏せるための秘密文字列表現。
 ///
 /// Codable では実値を運ぶが、`description` と `debugDescription` は `<redacted>` を返す。
-public struct ConverterSecretString: Codable, Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+public struct ConverterSecretString: Codable, Sendable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
     public var value: String
 
     public init(_ value: String) {
@@ -321,6 +325,17 @@ public struct ConverterTextContext: Codable, Sendable, Equatable {
     }
 }
 
+/// アプリ切替後の最初のキーイベントと同時にServerへ適用するセッション初期値。
+public struct ConverterSessionActivation: Codable, Sendable, Equatable {
+    public var config: ConverterSessionConfig
+    public var inputLanguage: InputLanguage
+
+    public init(config: ConverterSessionConfig, inputLanguage: InputLanguage) {
+        self.config = config
+        self.inputLanguage = inputLanguage
+    }
+}
+
 /// Client が受け取ったキーイベントと、その時点での IMK/UI 状態。
 ///
 /// Server はこの情報だけを見て変換処理を進め、Client に必要な effect と snapshot を返す。
@@ -337,6 +352,7 @@ public struct ConverterKeyEventRequest: Codable, Sendable, Equatable {
     public var typeBackSlash: Bool
     public var optionDirectInputText: String?
     public var context: ConverterTextContext
+    public var activation: ConverterSessionActivation?
     public var visibleCandidateStartIndex: Int
 
     public init(
@@ -352,6 +368,7 @@ public struct ConverterKeyEventRequest: Codable, Sendable, Equatable {
         typeBackSlash: Bool = false,
         optionDirectInputText: String? = nil,
         context: ConverterTextContext = .init(),
+        activation: ConverterSessionActivation? = nil,
         visibleCandidateStartIndex: Int = 0
     ) {
         self.eventID = eventID
@@ -366,6 +383,7 @@ public struct ConverterKeyEventRequest: Codable, Sendable, Equatable {
         self.typeBackSlash = typeBackSlash
         self.optionDirectInputText = optionDirectInputText
         self.context = context
+        self.activation = activation
         self.visibleCandidateStartIndex = visibleCandidateStartIndex
     }
 }

--- a/Core/Sources/Core/XPC/DebouncedActionScheduler.swift
+++ b/Core/Sources/Core/XPC/DebouncedActionScheduler.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// MainActor 上の処理を、最後の操作から一定時間後まで遅延するためのスケジューラ。
+///
+/// ConverterServer のように入力処理と低優先度の同期処理が同じactorを使う場合に、
+/// 入力が続いている間は同期処理をクリティカルパスへ入れないために使う。
+public final class DebouncedActionScheduler {
+    public typealias Action = @MainActor @Sendable () -> Void
+    public typealias Schedule = (TimeInterval, @escaping Action) -> Void
+
+    private let schedule: Schedule
+    private var generation: UInt64 = 0
+    private var pendingAction: Action?
+
+    public init(
+        schedule: @escaping Schedule = { delay, action in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                action()
+            }
+        }
+    ) {
+        self.schedule = schedule
+    }
+
+    @MainActor public var isPending: Bool {
+        pendingAction != nil
+    }
+
+    @MainActor public func schedule(after delay: TimeInterval, action: @escaping Action) {
+        pendingAction = action
+        arm(after: delay)
+    }
+
+    @MainActor public func postponeIfScheduled(after delay: TimeInterval) {
+        guard pendingAction != nil else {
+            return
+        }
+        arm(after: delay)
+    }
+
+    @MainActor public func cancel() {
+        generation &+= 1
+        pendingAction = nil
+    }
+
+    @MainActor private func arm(after delay: TimeInterval) {
+        generation &+= 1
+        let scheduledGeneration = generation
+        schedule(delay) { [weak self] in
+            guard let self,
+                  self.generation == scheduledGeneration,
+                  let action = self.pendingAction else {
+                return
+            }
+            self.pendingAction = nil
+            action()
+        }
+    }
+}

--- a/Core/Sources/Core/XPC/OrderedAsyncCommandQueue.swift
+++ b/Core/Sources/Core/XPC/OrderedAsyncCommandQueue.swift
@@ -16,20 +16,33 @@ public final class OrderedAsyncCommandQueue<Value> {
     private struct Entry {
         var operation: Operation
         var completion: @MainActor (Value) -> Void
+        var timeout: TimeInterval?
+        var timeoutOutcome: Outcome?
+        var onTimeout: @MainActor () -> Void
     }
 
     private var entries: [Entry] = []
-    private var isRunning = false
+    private var activeOperationID: UUID?
     private let scheduleRetry: (@escaping @MainActor @Sendable () -> Void) -> Void
+    private let scheduleTimeout: (TimeInterval, @escaping @MainActor @Sendable () -> Void) -> Void
 
     public init(
         scheduleRetry: @escaping (@escaping @MainActor @Sendable () -> Void) -> Void = { action in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 action()
             }
+        },
+        scheduleTimeout: @escaping (
+            TimeInterval,
+            @escaping @MainActor @Sendable () -> Void
+        ) -> Void = { timeout, action in
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+                action()
+            }
         }
     ) {
         self.scheduleRetry = scheduleRetry
+        self.scheduleTimeout = scheduleTimeout
     }
 
     @MainActor public var count: Int {
@@ -37,33 +50,62 @@ public final class OrderedAsyncCommandQueue<Value> {
     }
 
     @MainActor public func enqueue(
+        timeout: TimeInterval? = nil,
+        timeoutOutcome: Outcome? = nil,
+        onTimeout: @escaping @MainActor () -> Void = {},
         operation: @escaping Operation,
         completion: @escaping @MainActor (Value) -> Void
     ) {
-        entries.append(Entry(operation: operation, completion: completion))
+        entries.append(
+            Entry(
+                operation: operation,
+                completion: completion,
+                timeout: timeout,
+                timeoutOutcome: timeoutOutcome,
+                onTimeout: onTimeout
+            )
+        )
         startNextIfNeeded()
     }
 
     @MainActor private func startNextIfNeeded() {
-        guard !isRunning, let entry = entries.first else {
+        guard activeOperationID == nil, let entry = entries.first else {
             return
         }
-        isRunning = true
+        let operationID = UUID()
+        activeOperationID = operationID
         entry.operation { [weak self] outcome in
-            guard let self else {
-                return
-            }
-            switch outcome {
-            case .finish(let value):
-                self.entries.removeFirst()
-                self.isRunning = false
-                entry.completion(value)
-                self.startNextIfNeeded()
-            case .retry:
-                self.isRunning = false
-                self.scheduleRetry { [weak self] in
-                    self?.startNextIfNeeded()
+            self?.complete(operationID: operationID, entry: entry, outcome: outcome)
+        }
+        if let timeout = entry.timeout, let timeoutOutcome = entry.timeoutOutcome {
+            scheduleTimeout(timeout) { [weak self] in
+                guard let self, self.activeOperationID == operationID else {
+                    return
                 }
+                entry.onTimeout()
+                self.complete(operationID: operationID, entry: entry, outcome: timeoutOutcome)
+            }
+        }
+    }
+
+    @MainActor private func complete(
+        operationID: UUID,
+        entry: Entry,
+        outcome: Outcome
+    ) {
+        guard activeOperationID == operationID else {
+            return
+        }
+        switch outcome {
+        case .finish(let value):
+            entries.removeFirst()
+            activeOperationID = nil
+            entry.completion(value)
+            startNextIfNeeded()
+        case .retry:
+            activeOperationID = nil
+            scheduleRetry { [weak self] in
+                self?.startNextIfNeeded()
             }
         }
     }

--- a/Core/Tests/CoreTests/XPCTests/ConverterServerContractTests.swift
+++ b/Core/Tests/CoreTests/XPCTests/ConverterServerContractTests.swift
@@ -17,6 +17,52 @@ import Testing
     }
 }
 
+@Test func keyEventCommandCarriesDeferredActivation() throws {
+    let config = ConverterSessionConfig(
+        aiBackendPreference: .off,
+        openAIModelName: "model",
+        openAIEndpoint: "https://example.com",
+        openAIAPIKey: .init("secret"),
+        includeContextInAITransform: false
+    )
+    let request = ConverterKeyEventRequest(
+        eventID: 1,
+        event: KeyEventCore(
+            modifierFlags: [],
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            keyCode: 0
+        ),
+        inputStyle: .defaultRomanToKana,
+        liveConversionEnabled: true,
+        enableDebugWindow: false,
+        enableSuggestion: false,
+        typeBackSlash: true,
+        activation: .init(config: config, inputLanguage: .english)
+    )
+    let command = ConverterServerCommand.openSession(
+        sessionID: "session-1",
+        command: .handleKeyEvent(request)
+    )
+
+    let data = try ConverterServerCodec.encode(command)
+    let roundTrip = try ConverterServerCodec.decodeCommand(from: data)
+    guard case .openSession(
+        let sessionID,
+        .handleKeyEvent(let roundTripRequest)
+    ) = roundTrip else {
+        Issue.record("Expected atomic session opening with deferred activation, got \(roundTrip)")
+        return
+    }
+    guard let activation = roundTripRequest.activation else {
+        Issue.record("Expected deferred activation")
+        return
+    }
+    #expect(sessionID == "session-1")
+    #expect(activation.config == config)
+    #expect(activation.inputLanguage == .english)
+}
+
 @Test func converterServerSnapshotCarriesPredictionCandidates() throws {
     let snapshot = ConverterSessionSnapshot(
         markedText: ConverterSessionSnapshot.empty.markedText,

--- a/Core/Tests/CoreTests/XPCTests/DebouncedActionSchedulerTests.swift
+++ b/Core/Tests/CoreTests/XPCTests/DebouncedActionSchedulerTests.swift
@@ -1,0 +1,43 @@
+import Core
+import Testing
+
+@MainActor
+@Test func debouncedActionRunsOnlyAfterLatestSchedule() {
+    var scheduledActions: [@MainActor @Sendable () -> Void] = []
+    let scheduler = DebouncedActionScheduler { _, action in
+        scheduledActions.append(action)
+    }
+    var executionCount = 0
+
+    scheduler.schedule(after: 1) {
+        executionCount += 1
+    }
+    scheduler.postponeIfScheduled(after: 1)
+
+    #expect(scheduledActions.count == 2)
+    scheduledActions[0]()
+    #expect(executionCount == 0)
+    #expect(scheduler.isPending)
+
+    scheduledActions[1]()
+    #expect(executionCount == 1)
+    #expect(!scheduler.isPending)
+}
+
+@MainActor
+@Test func cancelledDebouncedActionDoesNotRun() {
+    var scheduledAction: (@MainActor @Sendable () -> Void)?
+    let scheduler = DebouncedActionScheduler { _, action in
+        scheduledAction = action
+    }
+    var didRun = false
+
+    scheduler.schedule(after: 1) {
+        didRun = true
+    }
+    scheduler.cancel()
+    scheduledAction?()
+
+    #expect(!didRun)
+    #expect(!scheduler.isPending)
+}

--- a/Core/Tests/CoreTests/XPCTests/OrderedAsyncCommandQueueTests.swift
+++ b/Core/Tests/CoreTests/XPCTests/OrderedAsyncCommandQueueTests.swift
@@ -62,3 +62,39 @@ import Testing
     #expect(completed == [7])
     #expect(queue.count == 0)
 }
+
+@MainActor
+@Test func orderedQueueTimesOutAndIgnoresLateReply() {
+    var scheduledTimeout: (@MainActor @Sendable () -> Void)?
+    let queue = OrderedAsyncCommandQueue<Int>(scheduleTimeout: { _, action in
+        scheduledTimeout = action
+    })
+    var firstFinish: OrderedAsyncCommandQueue<Int>.Finish?
+    var didStartSecondOperation = false
+    var completed: [Int] = []
+    var timeoutCount = 0
+
+    queue.enqueue(
+        timeout: 1,
+        timeoutOutcome: .finish(-1),
+        onTimeout: { timeoutCount += 1 },
+        operation: { firstFinish = $0 },
+        completion: { completed.append($0) }
+    )
+    queue.enqueue(
+        operation: { finish in
+            didStartSecondOperation = true
+            finish(.finish(2))
+        },
+        completion: { completed.append($0) }
+    )
+
+    scheduledTimeout?()
+    #expect(timeoutCount == 1)
+    #expect(didStartSecondOperation)
+    #expect(completed == [-1, 2])
+    #expect(queue.count == 0)
+
+    firstFinish?(.finish(1))
+    #expect(completed == [-1, 2])
+}

--- a/Tools/embed_converter_server.sh
+++ b/Tools/embed_converter_server.sh
@@ -36,15 +36,15 @@ fi
 
 if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ] && [ "${EXPANDED_CODE_SIGN_IDENTITY}" != "-" ]; then
     server_identifier="${PRODUCT_BUNDLE_IDENTIFIER}.ConverterServer"
-    # ConverterServerはログインユーザーのLaunchAgentとして動作する。ここにApp Groupや
-    # application-identifierを付与すると、独立したHelper用App IDのprovisioning profileが
-    # 必要になり、AMFIが実行前に拒否する。共有コンテナはCoreのAppGroupが通常の
-    # ファイルシステムパスとして解決するため、Helperにrestricted entitlementは不要。
+    # ConverterServerも学習データや個人化モデルをApp Groupから読む。entitlementなしで
+    # Group Containersを直接参照すると、macOSが「ほかのアプリのデータ」と判定して
+    # ファイルごとのアクセス確認を表示するため、埋め込みHelperにも同じGroupを付与する。
     codesign \
         --force \
         --sign "${EXPANDED_CODE_SIGN_IDENTITY}" \
         --identifier "${server_identifier}" \
         --options runtime \
+        --entitlements "${SRCROOT}/azooKeyMac/ConverterServer.entitlements" \
         --timestamp=none \
         "${server_destination}"
     codesign --verify --strict "${server_destination}"

--- a/azooKeyMac/InputController/ConverterServerClient.swift
+++ b/azooKeyMac/InputController/ConverterServerClient.swift
@@ -14,12 +14,15 @@ private enum ConverterServerXPC {
 
 @MainActor
 final class ConverterServerClient {
+    private static let commandTimeout: TimeInterval = 1
+
     private var connection: NSXPCConnection?
     private var sessionID: String?
     private var hasOpenedSession = false
     private var shouldAttemptReconnect = false
     private var nextReconnectAttemptDate = Date.distantPast
     private var isOpeningSession = false
+    private var openSessionGeneration: UInt64 = 0
     private var openSessionCompletions: [(String?) -> Void] = []
     private let commandQueue = OrderedAsyncCommandQueue<ConverterServerResponse?>()
 
@@ -48,11 +51,21 @@ final class ConverterServerClient {
             return
         }
         isOpeningSession = true
+        openSessionGeneration &+= 1
+        let generation = openSessionGeneration
         openSessionOnServer { [weak self] sessionID in
-            guard let self else {
+            guard let self, self.openSessionGeneration == generation else {
                 return
             }
+            self.openSessionGeneration &+= 1
             self.isOpeningSession = false
+            if let sessionID {
+                self.sessionID = sessionID
+                self.hasOpenedSession = true
+                self.shouldAttemptReconnect = false
+                self.nextReconnectAttemptDate = .distantPast
+                self.onLog?("ConverterServer session opened: \(sessionID)")
+            }
             let completions = self.openSessionCompletions
             self.openSessionCompletions.removeAll()
             completions.forEach { $0(sessionID) }
@@ -168,13 +181,26 @@ final class ConverterServerClient {
         completion: @escaping (ConverterServerResponse?) -> Void
     ) {
         commandQueue.enqueue(
+            timeout: Self.commandTimeout,
+            timeoutOutcome: retriesOnFailure ? .retry : .finish(nil),
+            onTimeout: { [weak self] in
+                self?.handleCommandTimeout()
+            },
             operation: { [weak self] finish in
                 guard let self else {
                     finish(.finish(nil))
                     return
                 }
+                let reconnectDelay = self.nextReconnectAttemptDate.timeIntervalSinceNow
+                if self.shouldAttemptReconnect, reconnectDelay > 0 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + reconnectDelay) {
+                        finish(.retry)
+                    }
+                    return
+                }
                 self.openSession { [weak self] sessionID in
                     guard let self, let sessionID else {
+                        self?.recordReconnectFailure()
                         finish(retriesOnFailure ? .retry : .finish(nil))
                         return
                     }
@@ -190,7 +216,9 @@ final class ConverterServerClient {
                     }
                 }
             },
-            completion: completion
+            completion: { response in
+                completion(response)
+            }
         )
     }
 
@@ -199,6 +227,11 @@ final class ConverterServerClient {
         completion: @escaping (ConverterServerResponse?) -> Void
     ) {
         commandQueue.enqueue(
+            timeout: Self.commandTimeout,
+            timeoutOutcome: .finish(nil),
+            onTimeout: { [weak self] in
+                self?.handleCommandTimeout()
+            },
             operation: { [weak self] finish in
                 guard let self else {
                     finish(.finish(nil))
@@ -208,7 +241,9 @@ final class ConverterServerClient {
                     finish(.finish(response))
                 }
             },
-            completion: completion
+            completion: { response in
+                completion(response)
+            }
         )
     }
 
@@ -264,18 +299,13 @@ final class ConverterServerClient {
     }
 
     private func openSessionOnServer(completion: ((String?) -> Void)? = nil) {
-        remoteObjectProxy { [weak self] proxy in
-            guard let self, let proxy else {
+        remoteObjectProxy { proxy in
+            guard let proxy else {
                 completion?(nil)
                 return
             }
             proxy.openSession { sessionID in
                 DispatchQueue.main.async {
-                    self.sessionID = sessionID
-                    self.hasOpenedSession = true
-                    self.shouldAttemptReconnect = false
-                    self.nextReconnectAttemptDate = .distantPast
-                    self.onLog?("ConverterServer session opened: \(sessionID)")
                     completion?(sessionID)
                 }
             }
@@ -306,7 +336,11 @@ final class ConverterServerClient {
     }
 
     private func resetConnection(preservingSession: Bool) {
+        let connection = self.connection
         self.connection = nil
+        connection?.interruptionHandler = nil
+        connection?.invalidationHandler = nil
+        connection?.invalidate()
         if sessionID != nil || hasOpenedSession {
             shouldAttemptReconnect = true
         }
@@ -316,12 +350,25 @@ final class ConverterServerClient {
     }
 
     private func invalidateConnection() {
-        connection?.invalidate()
         resetConnection(preservingSession: false)
     }
 
     private func recordReconnectFailure() {
         shouldAttemptReconnect = true
-        nextReconnectAttemptDate = Date().addingTimeInterval(2)
+        nextReconnectAttemptDate = Date().addingTimeInterval(0.2)
+    }
+
+    private func handleCommandTimeout() {
+        onLog?("ConverterServer command timed out")
+        recordReconnectFailure()
+        resetConnection(preservingSession: true)
+        guard isOpeningSession else {
+            return
+        }
+        openSessionGeneration &+= 1
+        isOpeningSession = false
+        let completions = openSessionCompletions
+        openSessionCompletions.removeAll()
+        completions.forEach { $0(nil) }
     }
 }

--- a/azooKeyMac/InputController/ConverterServerClient.swift
+++ b/azooKeyMac/InputController/ConverterServerClient.swift
@@ -21,9 +21,6 @@ final class ConverterServerClient {
     private var hasOpenedSession = false
     private var shouldAttemptReconnect = false
     private var nextReconnectAttemptDate = Date.distantPast
-    private var isOpeningSession = false
-    private var openSessionGeneration: UInt64 = 0
-    private var openSessionCompletions: [(String?) -> Void] = []
     private let commandQueue = OrderedAsyncCommandQueue<ConverterServerResponse?>()
 
     nonisolated init() {}
@@ -37,39 +34,6 @@ final class ConverterServerClient {
     }
     var pendingCommandCount: Int {
         commandQueue.count
-    }
-
-    func openSession(completion: ((String?) -> Void)? = nil) {
-        if let sessionID {
-            completion?(sessionID)
-            return
-        }
-        if let completion {
-            openSessionCompletions.append(completion)
-        }
-        guard !isOpeningSession else {
-            return
-        }
-        isOpeningSession = true
-        openSessionGeneration &+= 1
-        let generation = openSessionGeneration
-        openSessionOnServer { [weak self] sessionID in
-            guard let self, self.openSessionGeneration == generation else {
-                return
-            }
-            self.openSessionGeneration &+= 1
-            self.isOpeningSession = false
-            if let sessionID {
-                self.sessionID = sessionID
-                self.hasOpenedSession = true
-                self.shouldAttemptReconnect = false
-                self.nextReconnectAttemptDate = .distantPast
-                self.onLog?("ConverterServer session opened: \(sessionID)")
-            }
-            let completions = self.openSessionCompletions
-            self.openSessionCompletions.removeAll()
-            completions.forEach { $0(sessionID) }
-        }
     }
 
     func closeSession() {
@@ -168,7 +132,7 @@ final class ConverterServerClient {
         _ commandBuilder: @escaping (String) -> ConverterSessionCommand,
         completion: @escaping (ConverterServerResponse?) -> Void
     ) {
-        guard sessionID != nil || isOpeningSession else {
+        guard sessionID != nil else {
             completion(nil)
             return
         }
@@ -180,6 +144,7 @@ final class ConverterServerClient {
         retriesOnFailure: Bool,
         completion: @escaping (ConverterServerResponse?) -> Void
     ) {
+        var proposedSessionID: String?
         commandQueue.enqueue(
             timeout: Self.commandTimeout,
             timeoutOutcome: retriesOnFailure ? .retry : .finish(nil),
@@ -198,21 +163,27 @@ final class ConverterServerClient {
                     }
                     return
                 }
-                self.openSession { [weak self] sessionID in
-                    guard let self, let sessionID else {
-                        self?.recordReconnectFailure()
-                        finish(retriesOnFailure ? .retry : .finish(nil))
+                let sessionID = self.sessionID ?? proposedSessionID ?? UUID().uuidString
+                proposedSessionID = sessionID
+                let sessionCommand = commandBuilder(sessionID)
+                let command: ConverterServerCommand = if self.sessionID == nil {
+                    .openSession(sessionID: sessionID, command: sessionCommand)
+                } else {
+                    .session(sessionID: sessionID, command: sessionCommand)
+                }
+                self.sendResolved(command) { [weak self] response in
+                    guard let self else {
+                        finish(.finish(nil))
                         return
                     }
-                    self.sendResolved(
-                        .session(sessionID: sessionID, command: commandBuilder(sessionID))
-                    ) { [weak self] response in
-                        if response == nil, retriesOnFailure {
-                            self?.recordReconnectFailure()
-                            finish(.retry)
-                        } else {
-                            finish(.finish(response))
-                        }
+                    if response != nil, self.sessionID == nil {
+                        self.acceptOpenedSession(sessionID)
+                    }
+                    if response == nil, retriesOnFailure {
+                        self.recordReconnectFailure()
+                        finish(.retry)
+                    } else {
+                        finish(.finish(response))
                     }
                 }
             },
@@ -298,20 +269,6 @@ final class ConverterServerClient {
         }
     }
 
-    private func openSessionOnServer(completion: ((String?) -> Void)? = nil) {
-        remoteObjectProxy { proxy in
-            guard let proxy else {
-                completion?(nil)
-                return
-            }
-            proxy.openSession { sessionID in
-                DispatchQueue.main.async {
-                    completion?(sessionID)
-                }
-            }
-        }
-    }
-
     private func ensureConnection() -> NSXPCConnection {
         if let connection {
             return connection
@@ -358,17 +315,17 @@ final class ConverterServerClient {
         nextReconnectAttemptDate = Date().addingTimeInterval(0.2)
     }
 
+    private func acceptOpenedSession(_ sessionID: String) {
+        self.sessionID = sessionID
+        hasOpenedSession = true
+        shouldAttemptReconnect = false
+        nextReconnectAttemptDate = .distantPast
+        onLog?("ConverterServer session opened: \(sessionID)")
+    }
+
     private func handleCommandTimeout() {
         onLog?("ConverterServer command timed out")
         recordReconnectFailure()
         resetConnection(preservingSession: true)
-        guard isOpeningSession else {
-            return
-        }
-        openSessionGeneration &+= 1
-        isOpeningSession = false
-        let completions = openSessionCompletions
-        openSessionCompletions.removeAll()
-        completions.forEach { $0(nil) }
     }
 }

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -11,6 +11,7 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     private var pendingKeyEventCount = 0
     private var nextKeyEventID: UInt64 = 0
     private var activationGeneration: UInt64 = 0
+    private var pendingConverterServerActivation: ConverterSessionActivation?
     var liveConversionEnabled: Bool {
         Config.LiveConversion().value
     }
@@ -146,26 +147,14 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     override func activateServer(_ sender: Any!) {
         super.activateServer(sender)
         self.activationGeneration &+= 1
-        let activationGeneration = self.activationGeneration
         self.updateLiveConversionToggleMenuItem(newValue: self.liveConversionEnabled)
         self.updateTransformSelectedTextMenuItemEnabledState()
         // ピン留めプロンプトのキャッシュを更新
         self.reloadPinnedPromptsCache()
-        self.syncConverterServerSessionConfig()
-        self.converterServerClient.send(
-            { _ in .lifecycle(.synchronizeInputLanguage(self.inputLanguage)) },
-            completion: { _ in }
+        self.pendingConverterServerActivation = ConverterSessionActivation(
+            config: self.converterServerSessionConfig,
+            inputLanguage: self.inputLanguage
         )
-        self.converterServerClient.send({ _ in .lifecycle(.activate) }, completion: { [weak self] response in
-            guard let self,
-                  self.activationGeneration == activationGeneration,
-                  let response else {
-                return
-            }
-            self.currentConverterView = response.snapshot
-            self.inputState = response.inputState.inputState
-            self.inputLanguage = response.inputLanguage ?? self.inputLanguage
-        })
 
         if let client = sender as? IMKTextInput {
             client.overrideKeyboard(withKeyboardNamed: Config.KeyboardLayout().value.layoutIdentifier)
@@ -186,8 +175,10 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     @MainActor
     override func deactivateServer(_ sender: Any!) {
         self.activationGeneration &+= 1
+        self.pendingConverterServerActivation = nil
         self.converterServerClient.sendIfSessionOpen({ _ in .lifecycle(.deactivate) }, completion: { _ in })
         self.currentConverterView = nil
+        self.inputState = .none
         self.candidatesWindow.orderOut(nil)
         self.predictionWindow.orderOut(nil)
         self.replaceSuggestionWindow.orderOut(nil)
@@ -373,8 +364,10 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
             enableOptionDirectFullWidthInput: Config.OptionDirectFullWidthInput().value,
             typeBackSlash: Config.TypeBackSlash().value,
             optionDirectInputText: optionDirectInputText,
-            context: self.currentConverterTextContext()
+            context: self.currentConverterTextContext(),
+            activation: self.pendingConverterServerActivation
         )
+        self.pendingConverterServerActivation = nil
         self.pendingKeyEventCount += 1
         let activationGeneration = self.activationGeneration
         self.converterServerClient.sendKeyEvent(request) { [weak self] response in


### PR DESCRIPTION
## 概要

ConverterServer 内で `KanaKanjiConverter` を入力セッションごとに生成せず、全実行レーンから1つの Converter を共有するようにします。入力途中の状態は AZKKC の変換セッションで分離します。

あわせて、XPC の reply 欠落時にクライアントの順序付きキューが永久停止しないための復旧処理と、アプリ切替時の入力待ちを起こしていた学習データ保存処理の遅延・省略を追加します。

## 原因

- ConverterServer プロセス自体は共有されていましたが、`openSession` のたびに `KanaKanjiConverter.withDefaultDictionary()` を生成していました。
- そのため新しいアプリの入力セッションごとに辞書・モデル・Converter キャッシュの初期化コストが発生していました。
- `OrderedAsyncCommandQueue` は XPC reply が欠落すると先頭処理を完了できず、以降の入力がすべて待ち続ける構造でした。
- 古い `NSXPCConnection` を参照から外すだけで明示的に invalidate しておらず、接続が残るケースがありました。
- アプリ切替時の `activateServer` が設定同期・言語同期・activateを別々のXPCとしてキー入力より先に直列化していました。
- 新規アプリの最初の入力は、`openSession` の応答後に改めてキーを送る2往復になっていました。
- 旧アプリの `deactivate` は非同期でServerへ送られますが、Server上では学習データを同期保存していました。クライアント側では切替が完了しているため、新アプリの最初のキーが共有Serverの保存完了を待つ状態になっていました。
- AZKKCの学習保存は変更がない場合も既存学習辞書をマージし、メモリキャッシュを破棄していました。

## 変更内容

- ConverterServer 起動時に `KanaKanjiConverter` を1回だけ生成
- 各入力セッションは軽量な AZKKC の変換セッション ID と `SegmentsManager` のみ保持
- Converter 操作を MainActor 上で直列化し、処理ごとに対象の変換セッションを選択
- ユーザー辞書再読込・学習リセットを共有 Converter に1回だけ適用
- 順序付きコマンドキューへタイムアウトを追加し、遅延 reply を operation ID で無視
- キーイベントはタイムアウト後も同じ event ID のまま再送し、Server 側の既存重複排除で二重適用を防止
- タイムアウト時は古い XPC 接続を明示的に invalidate して再接続
- activationを最初のキーイベントへ同梱し、切替時の先行XPCを削除
- セッション作成・activation・最初のキー処理を1つのServerコマンドとして原子的に実行
- `deactivate` では入力状態だけ即時リセットし、学習データの永続化は入力が2秒途切れるまで遅延
- 遅延保存が待機中に別コマンドを処理した場合は、保存をそのコマンド完了後まで再延期
- AZKKC側で未保存の学習変更がない場合は、辞書マージとメモリキャッシュ破棄を省略
- ConverterServerにもApp Group entitlementを付与し、Group Containers参照時のファイルアクセス確認を防止
- 左右文脈の取得方法は変更せず、プロセス分離前と同じ入力情報を維持
- ログにはタイムアウトの事実だけを記録し、キー内容は追加していません

## 依存 PR

- https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/353

現時点では上記 PR のコミット `67ec8e68d17a534b5b9929b920995ef3811e89fe` を参照しています。

## テスト

- `swift test --package-path Core`（67 tests passed）
- AZKKC: `swift test --filter LearningMemoryTests`（5 tests passed）
- `xcodebuild -project azooKeyMac.xcodeproj -scheme azooKeyMac -configuration Debug test CODE_SIGNING_ALLOWED=NO -only-testing:azooKeyMacTests`（9 tests passed）
- `swiftlint lint --strict`
- `git diff --check`
- `./install.sh --dry-run`（archive succeeded）
- archive内のConverterServerにApp Group entitlementが付与されていることを `codesign` で確認

実機への再インストールはこの更新では行っていません。
